### PR TITLE
モジュール登録のDI解析を統一メソッドに集約

### DIFF
--- a/src/analyzer/js/context.rs
+++ b/src/analyzer/js/context.rs
@@ -25,6 +25,34 @@ pub(super) struct DiScope {
     pub(super) has_root_scope: bool,
 }
 
+/// ノードから抽出されたDI情報
+///
+/// 配列記法・関数パラメータ・識別子解決など、あらゆるパターンから
+/// 統一的にDI情報を取得した結果をまとめる構造体
+pub(super) struct DiInfo {
+    /// $以外のDIされた依存サービス名
+    pub(super) injected_services: Vec<String>,
+    /// $scope がDIされているか
+    pub(super) has_scope: bool,
+    /// $rootScope がDIされているか
+    pub(super) has_root_scope: bool,
+}
+
+impl DiInfo {
+    pub(super) fn empty() -> Self {
+        Self {
+            injected_services: Vec::new(),
+            has_scope: false,
+            has_root_scope: false,
+        }
+    }
+
+    /// DI情報があるかどうか（サービス、$scope、$rootScope のいずれか）
+    pub(super) fn has_any(&self) -> bool {
+        !self.injected_services.is_empty() || self.has_scope || self.has_root_scope
+    }
+}
+
 /// 解析コンテキスト
 pub(super) struct AnalyzerContext {
     /// 現在有効なDIスコープのスタック

--- a/src/analyzer/js/di.rs
+++ b/src/analyzer/js/di.rs
@@ -1,7 +1,7 @@
 use tower_lsp::lsp_types::Url;
 use tree_sitter::Node;
 
-use super::context::AnalyzerContext;
+use super::context::{AnalyzerContext, DiInfo};
 use super::AngularJsAnalyzer;
 use crate::model::{ControllerScope, Span, SymbolReference};
 
@@ -33,6 +33,64 @@ impl AngularJsAnalyzer {
             }
         }
         None
+    }
+
+    /// ノードからDI情報を汎用的に抽出する
+    ///
+    /// ノードの種類に応じて適切な方法でDI情報を解析する。
+    /// 識別子の場合は変数宣言・関数宣言・class宣言を探索して実体を解決し、
+    /// 解決先の中身に基づいて判断する。
+    ///
+    /// 認識パターン:
+    /// - 配列記法: `['$scope', 'Service', function($scope, Service) {}]`
+    /// - 関数式: `function($scope, Service) {}`
+    /// - アロー関数: `($scope, Service) => {}`
+    /// - class式/class宣言: `class { constructor($scope, Service) {} }`
+    /// - 関数宣言: `function MyCtrl($scope, Service) {}`
+    /// - 識別子: 一時変数・関数参照・class参照を解決して中身に基づき判断
+    pub(super) fn extract_di_info(&self, node: Node, source: &str) -> DiInfo {
+        match node.kind() {
+            "array" => DiInfo {
+                injected_services: self.collect_injected_services(node, source),
+                has_scope: self.has_scope_in_di_array(node, source),
+                has_root_scope: self.has_root_scope_in_di_array(node, source),
+            },
+            "function_expression" | "arrow_function" | "function_declaration"
+            | "class" | "class_declaration" => DiInfo {
+                injected_services: self.collect_services_from_function_params(node, source),
+                has_scope: self.has_scope_in_function_params(node, source),
+                has_root_scope: self.has_root_scope_in_function_params(node, source),
+            },
+            "identifier" => {
+                // 識別子の場合は実体を解決して中身を見る
+                let ref_name = self.node_text(node, source);
+                let root = {
+                    let mut current = node;
+                    while let Some(parent) = current.parent() {
+                        current = parent;
+                    }
+                    current
+                };
+
+                // 1. 変数宣言の値を探して、中身に基づいて判断
+                //    例: var deps = ['$scope', function($scope) {}];
+                if let Some(value_node) = self.find_variable_value_for_di(root, source, &ref_name) {
+                    return self.extract_di_info(value_node, source);
+                }
+                // 2. 関数宣言を探す
+                //    例: function MyController($scope) {}
+                if let Some(func_decl) = self.find_function_declaration(root, source, &ref_name) {
+                    return self.extract_di_info(func_decl, source);
+                }
+                // 3. class宣言を探す
+                //    例: class MyController { constructor($scope) {} }
+                if let Some(class_decl) = self.find_class_declaration(root, source, &ref_name) {
+                    return self.extract_di_info(class_decl, source);
+                }
+                DiInfo::empty()
+            }
+            _ => DiInfo::empty(),
+        }
     }
 
     /// `$inject` パターンを解析する
@@ -281,105 +339,6 @@ impl AngularJsAnalyzer {
         }
 
         services
-    }
-
-    /// 関数参照またはclass参照（identifier）から関数宣言/class宣言を探し、パラメータに $scope があるかチェック
-    ///
-    /// 関数参照パターン用:
-    /// ```javascript
-    /// .controller('Ctrl', MyController);
-    /// function MyController($scope, Service) {}
-    /// class MyController { constructor($scope, Service) {} }
-    /// ```
-    pub(super) fn has_scope_in_function_ref(&self, node: Node, source: &str) -> bool {
-        if node.kind() != "identifier" {
-            return false;
-        }
-
-        let ref_name = self.node_text(node, source);
-        let root = {
-            let mut current = node;
-            while let Some(parent) = current.parent() {
-                current = parent;
-            }
-            current
-        };
-
-        // まず関数宣言を探す
-        if let Some(func_decl) = self.find_function_declaration(root, source, &ref_name) {
-            return self.has_scope_in_function_params(func_decl, source);
-        }
-        // 次にclass宣言を探す
-        if let Some(class_decl) = self.find_class_declaration(root, source, &ref_name) {
-            return self.has_scope_in_function_params(class_decl, source);
-        }
-        false
-    }
-
-    /// 関数参照またはclass参照（identifier）から関数宣言/class宣言を探し、パラメータに $rootScope があるかチェック
-    ///
-    /// 関数参照パターン用:
-    /// ```javascript
-    /// .run(AppInit);
-    /// function AppInit($rootScope) {}
-    /// class AppInit { constructor($rootScope) {} }
-    /// ```
-    pub(super) fn has_root_scope_in_function_ref(&self, node: Node, source: &str) -> bool {
-        if node.kind() != "identifier" {
-            return false;
-        }
-
-        let ref_name = self.node_text(node, source);
-        let root = {
-            let mut current = node;
-            while let Some(parent) = current.parent() {
-                current = parent;
-            }
-            current
-        };
-
-        // まず関数宣言を探す
-        if let Some(func_decl) = self.find_function_declaration(root, source, &ref_name) {
-            return self.has_root_scope_in_function_params(func_decl, source);
-        }
-        // 次にclass宣言を探す
-        if let Some(class_decl) = self.find_class_declaration(root, source, &ref_name) {
-            return self.has_root_scope_in_function_params(class_decl, source);
-        }
-        false
-    }
-
-    /// 関数参照またはclass参照（identifier）から関数宣言/class宣言を探し、パラメータからサービスを収集
-    ///
-    /// 関数参照パターン用:
-    /// ```javascript
-    /// .controller('Ctrl', MyController);
-    /// function MyController($scope, Service) {}
-    /// class MyController { constructor($scope, Service) {} }
-    /// ```
-    pub(super) fn collect_services_from_function_ref(&self, node: Node, source: &str) -> Vec<String> {
-        if node.kind() != "identifier" {
-            return Vec::new();
-        }
-
-        let ref_name = self.node_text(node, source);
-        let root = {
-            let mut current = node;
-            while let Some(parent) = current.parent() {
-                current = parent;
-            }
-            current
-        };
-
-        // まず関数宣言を探す
-        if let Some(func_decl) = self.find_function_declaration(root, source, &ref_name) {
-            return self.collect_services_from_function_params(func_decl, source);
-        }
-        // 次にclass宣言を探す
-        if let Some(class_decl) = self.find_class_declaration(root, source, &ref_name) {
-            return self.collect_services_from_function_params(class_decl, source);
-        }
-        Vec::new()
     }
 
     /// 関数本体の行範囲を取得する

--- a/src/analyzer/js/tests/mod.rs
+++ b/src/analyzer/js/tests/mod.rs
@@ -1,1 +1,618 @@
-// Tests will be added as needed
+use std::sync::Arc;
+
+use tower_lsp::lsp_types::Url;
+
+use crate::index::Index;
+use crate::model::SymbolKind;
+
+use super::AngularJsAnalyzer;
+
+fn test_uri() -> Url {
+    Url::parse("file:///test.js").unwrap()
+}
+
+fn analyze(source: &str) -> Arc<Index> {
+    let index = Arc::new(Index::new());
+    let analyzer = AngularJsAnalyzer::new(Arc::clone(&index));
+    analyzer.analyze_document(&test_uri(), source);
+    index
+}
+
+/// ヘルパー: 指定名・指定種類の定義が存在するか
+fn has_definition(index: &Index, name: &str, kind: SymbolKind) -> bool {
+    index
+        .definitions
+        .get_definitions(name)
+        .iter()
+        .any(|s| s.kind == kind)
+}
+
+/// ヘルパー: 指定URIの全コントローラースコープを取得
+fn get_controller_scopes(index: &Index) -> Vec<crate::model::ControllerScope> {
+    index.controllers.get_all_controller_scopes()
+}
+
+/// ヘルパー: 指定名のコントローラースコープを取得
+fn get_scope_for(index: &Index, name: &str) -> Option<crate::model::ControllerScope> {
+    get_controller_scopes(index)
+        .into_iter()
+        .find(|s| s.name == name)
+}
+
+// ==========================================================================
+// 基本パターン: DI配列記法
+// ==========================================================================
+
+#[test]
+fn test_di_array_controller() {
+    let index = analyze(
+        r#"
+angular.module('app', [])
+.controller('MyCtrl', ['$scope', 'UserService', function($scope, UserService) {
+    $scope.name = 'test';
+}]);
+"#,
+    );
+
+    assert!(has_definition(&index, "MyCtrl", SymbolKind::Controller));
+    let scope = get_scope_for(&index, "MyCtrl").expect("controller scope should exist");
+    assert!(scope.injected_services.contains(&"UserService".to_string()));
+}
+
+#[test]
+fn test_di_array_service() {
+    let index = analyze(
+        r#"
+angular.module('app', [])
+.service('DataService', ['$http', 'AuthService', function($http, AuthService) {
+    this.getData = function() {};
+}]);
+"#,
+    );
+
+    assert!(has_definition(&index, "DataService", SymbolKind::Service));
+    let scope = get_scope_for(&index, "DataService").expect("service scope should exist");
+    assert!(scope.injected_services.contains(&"AuthService".to_string()));
+}
+
+#[test]
+fn test_di_array_factory() {
+    let index = analyze(
+        r#"
+angular.module('app', [])
+.factory('AuthFactory', ['$http', 'TokenService', function($http, TokenService) {
+    return { login: function() {} };
+}]);
+"#,
+    );
+
+    assert!(has_definition(&index, "AuthFactory", SymbolKind::Factory));
+    let scope = get_scope_for(&index, "AuthFactory").expect("factory scope should exist");
+    assert!(scope.injected_services.contains(&"TokenService".to_string()));
+}
+
+// ==========================================================================
+// 直接関数記法
+// ==========================================================================
+
+#[test]
+fn test_direct_function_controller() {
+    let index = analyze(
+        r#"
+angular.module('app', [])
+.controller('DirectCtrl', function($scope, MyService) {
+    $scope.value = 1;
+});
+"#,
+    );
+
+    assert!(has_definition(&index, "DirectCtrl", SymbolKind::Controller));
+    let scope = get_scope_for(&index, "DirectCtrl").expect("controller scope should exist");
+    assert!(scope.injected_services.contains(&"MyService".to_string()));
+}
+
+// ==========================================================================
+// 関数参照パターン（identifier → 関数宣言）
+// ==========================================================================
+
+#[test]
+fn test_function_ref_controller() {
+    let index = analyze(
+        r#"
+function RefCtrl($scope, UserService) {
+    $scope.users = [];
+}
+
+angular.module('app', [])
+.controller('RefCtrl', RefCtrl);
+"#,
+    );
+
+    assert!(has_definition(&index, "RefCtrl", SymbolKind::Controller));
+    let scope = get_scope_for(&index, "RefCtrl").expect("controller scope should exist");
+    assert!(scope.injected_services.contains(&"UserService".to_string()));
+}
+
+// ==========================================================================
+// class参照パターン（identifier → class宣言）
+// ==========================================================================
+
+#[test]
+fn test_class_ref_controller() {
+    let index = analyze(
+        r#"
+class ClassCtrl {
+    constructor($scope, DataService) {
+        this.data = [];
+    }
+}
+
+angular.module('app', [])
+.controller('ClassCtrl', ClassCtrl);
+"#,
+    );
+
+    assert!(has_definition(&index, "ClassCtrl", SymbolKind::Controller));
+    let scope = get_scope_for(&index, "ClassCtrl").expect("controller scope should exist");
+    assert!(scope.injected_services.contains(&"DataService".to_string()));
+}
+
+// ==========================================================================
+// class式パターン（インライン class）
+// ==========================================================================
+
+#[test]
+fn test_inline_class_controller() {
+    let index = analyze(
+        r#"
+angular.module('app', [])
+.controller('InlineClassCtrl', ['$scope', 'SomeService', class {
+    constructor($scope, SomeService) {
+        this.items = [];
+    }
+}]);
+"#,
+    );
+
+    assert!(has_definition(
+        &index,
+        "InlineClassCtrl",
+        SymbolKind::Controller
+    ));
+    let scope = get_scope_for(&index, "InlineClassCtrl").expect("controller scope should exist");
+    assert!(scope.injected_services.contains(&"SomeService".to_string()));
+}
+
+// ==========================================================================
+// 一時変数解決パターン（identifier → 変数 → 配列）
+// これが今回の新機能: 一時変数の中身を見て判断する
+// ==========================================================================
+
+#[test]
+fn test_variable_holding_di_array_for_run() {
+    let index = analyze(
+        r#"
+var runDeps = ['$rootScope', function($rootScope) {
+    $rootScope.appName = 'MyApp';
+}];
+
+angular.module('app', [])
+.run(runDeps);
+"#,
+    );
+
+    // run() には名前がないので定義は登録されないが、
+    // コントローラースコープは作られない（runだから）。
+    // DiScopeとしてcontextに追加されるが、indexのcontrollerには追加されない。
+    // → モジュール定義が登録されていることを確認
+    assert!(has_definition(&index, "app", SymbolKind::Module));
+}
+
+#[test]
+fn test_variable_holding_function_for_controller() {
+    let index = analyze(
+        r#"
+var MyCtrlFn = function($scope, OrderService) {
+    $scope.orders = [];
+};
+
+angular.module('app', [])
+.controller('VarCtrl', MyCtrlFn);
+"#,
+    );
+
+    assert!(has_definition(&index, "VarCtrl", SymbolKind::Controller));
+    let scope = get_scope_for(&index, "VarCtrl").expect("controller scope should exist");
+    assert!(scope.injected_services.contains(&"OrderService".to_string()));
+}
+
+#[test]
+fn test_variable_holding_function_for_service() {
+    let index = analyze(
+        r#"
+var DataSvcImpl = function($http, CacheService) {
+    this.fetch = function() {};
+};
+
+angular.module('app', [])
+.service('DataSvc', DataSvcImpl);
+"#,
+    );
+
+    assert!(has_definition(&index, "DataSvc", SymbolKind::Service));
+    let scope = get_scope_for(&index, "DataSvc").expect("service scope should exist");
+    assert!(scope.injected_services.contains(&"CacheService".to_string()));
+}
+
+// ==========================================================================
+// $inject パターン
+// ==========================================================================
+
+#[test]
+fn test_inject_pattern_controller() {
+    let index = analyze(
+        r#"
+function InjectCtrl($scope, ApiService) {
+    $scope.data = [];
+}
+InjectCtrl.$inject = ['$scope', 'ApiService'];
+
+angular.module('app', [])
+.controller('InjectCtrl', InjectCtrl);
+"#,
+    );
+
+    assert!(has_definition(&index, "InjectCtrl", SymbolKind::Controller));
+    let scope = get_scope_for(&index, "InjectCtrl").expect("controller scope should exist");
+    assert!(scope.injected_services.contains(&"ApiService".to_string()));
+}
+
+// ==========================================================================
+// .run() / .config() パターン
+// ==========================================================================
+
+#[test]
+fn test_run_with_di_array() {
+    let index = analyze(
+        r#"
+angular.module('app', [])
+.run(['$rootScope', 'AuthService', function($rootScope, AuthService) {
+    $rootScope.isLoggedIn = false;
+}]);
+"#,
+    );
+
+    // run はコントローラーではないのでcontroller_scopeには登録されない
+    // ただし定義はモジュールとして存在する
+    assert!(has_definition(&index, "app", SymbolKind::Module));
+}
+
+#[test]
+fn test_run_with_function_ref() {
+    let index = analyze(
+        r#"
+function AppInit($rootScope) {
+    $rootScope.ready = true;
+}
+
+angular.module('app', [])
+.run(AppInit);
+"#,
+    );
+
+    assert!(has_definition(&index, "app", SymbolKind::Module));
+}
+
+// ==========================================================================
+// その他の登録タイプ
+// ==========================================================================
+
+#[test]
+fn test_directive_definition() {
+    let index = analyze(
+        r#"
+angular.module('app', [])
+.directive('myDirective', ['$compile', 'UtilService', function($compile, UtilService) {
+    return { restrict: 'E' };
+}]);
+"#,
+    );
+
+    assert!(has_definition(&index, "myDirective", SymbolKind::Directive));
+}
+
+#[test]
+fn test_filter_definition() {
+    let index = analyze(
+        r#"
+angular.module('app', [])
+.filter('myFilter', function() {
+    return function(input) { return input; };
+});
+"#,
+    );
+
+    assert!(has_definition(&index, "myFilter", SymbolKind::Filter));
+}
+
+#[test]
+fn test_constant_definition() {
+    let index = analyze(
+        r#"
+angular.module('app', [])
+.constant('API_URL', 'https://api.example.com');
+"#,
+    );
+
+    assert!(has_definition(&index, "API_URL", SymbolKind::Constant));
+}
+
+#[test]
+fn test_value_definition() {
+    let index = analyze(
+        r#"
+angular.module('app', [])
+.value('appConfig', { debug: true });
+"#,
+    );
+
+    assert!(has_definition(&index, "appConfig", SymbolKind::Value));
+}
+
+#[test]
+fn test_provider_definition() {
+    let index = analyze(
+        r#"
+angular.module('app', [])
+.provider('myProvider', function() {
+    this.$get = function() { return {}; };
+});
+"#,
+    );
+
+    assert!(has_definition(&index, "myProvider", SymbolKind::Provider));
+}
+
+// ==========================================================================
+// チェーン呼び出しパターン
+// ==========================================================================
+
+#[test]
+fn test_chained_registration() {
+    let index = analyze(
+        r#"
+angular.module('app', [])
+.controller('Ctrl1', ['$scope', function($scope) {}])
+.service('Svc1', ['$http', function($http) {}])
+.factory('Fac1', function() { return {}; });
+"#,
+    );
+
+    assert!(has_definition(&index, "Ctrl1", SymbolKind::Controller));
+    assert!(has_definition(&index, "Svc1", SymbolKind::Service));
+    assert!(has_definition(&index, "Fac1", SymbolKind::Factory));
+}
+
+// ==========================================================================
+// $routeProvider.when() パターン
+// ==========================================================================
+
+#[test]
+fn test_route_with_inline_controller() {
+    let index = analyze(
+        r#"
+angular.module('app', [])
+.config(['$routeProvider', function($routeProvider) {
+    $routeProvider.when('/home', {
+        templateUrl: 'home.html',
+        controller: ['$scope', 'HomeService', function($scope, HomeService) {
+            $scope.welcome = 'Hello';
+        }]
+    });
+}]);
+"#,
+    );
+
+    // route の inline controller は "route" という名前で登録される
+    let scope = get_scope_for(&index, "route").expect("route controller scope should exist");
+    assert!(scope.injected_services.contains(&"HomeService".to_string()));
+}
+
+#[test]
+fn test_route_with_string_controller_ref() {
+    let index = analyze(
+        r#"
+angular.module('app', [])
+.config(['$routeProvider', function($routeProvider) {
+    $routeProvider.when('/users', {
+        templateUrl: 'users.html',
+        controller: 'UsersCtrl'
+    });
+}]);
+"#,
+    );
+
+    // controller: 'UsersCtrl' は参照として登録される
+    let refs = index.definitions.get_references("UsersCtrl");
+    assert!(!refs.is_empty(), "reference to UsersCtrl should be registered");
+}
+
+// ==========================================================================
+// 一時変数解決: 複合ケース
+// ==========================================================================
+
+#[test]
+fn test_variable_holding_di_array_for_controller() {
+    let index = analyze(
+        r#"
+var ctrlDeps = ['$scope', 'ProductService', function($scope, ProductService) {
+    $scope.products = [];
+}];
+
+angular.module('app', [])
+.controller('VarArrayCtrl', ctrlDeps);
+"#,
+    );
+
+    assert!(has_definition(
+        &index,
+        "VarArrayCtrl",
+        SymbolKind::Controller
+    ));
+    let scope = get_scope_for(&index, "VarArrayCtrl").expect("controller scope should exist");
+    assert!(scope
+        .injected_services
+        .contains(&"ProductService".to_string()));
+}
+
+#[test]
+fn test_variable_holding_arrow_function() {
+    let index = analyze(
+        r#"
+var arrowFn = ($scope, LogService) => {
+    $scope.logs = [];
+};
+
+angular.module('app', [])
+.controller('ArrowCtrl', arrowFn);
+"#,
+    );
+
+    assert!(has_definition(&index, "ArrowCtrl", SymbolKind::Controller));
+    let scope = get_scope_for(&index, "ArrowCtrl").expect("controller scope should exist");
+    assert!(scope.injected_services.contains(&"LogService".to_string()));
+}
+
+#[test]
+fn test_const_variable_holding_function() {
+    let index = analyze(
+        r#"
+const svcImpl = function($http, CacheService) {
+    this.get = function() {};
+};
+
+angular.module('app', [])
+.service('ConstSvc', svcImpl);
+"#,
+    );
+
+    assert!(has_definition(&index, "ConstSvc", SymbolKind::Service));
+    let scope = get_scope_for(&index, "ConstSvc").expect("service scope should exist");
+    assert!(scope.injected_services.contains(&"CacheService".to_string()));
+}
+
+#[test]
+fn test_let_variable_holding_function() {
+    let index = analyze(
+        r#"
+let factoryFn = function($q, DataService) {
+    return { process: function() {} };
+};
+
+angular.module('app', [])
+.factory('LetFactory', factoryFn);
+"#,
+    );
+
+    assert!(has_definition(&index, "LetFactory", SymbolKind::Factory));
+    let scope = get_scope_for(&index, "LetFactory").expect("factory scope should exist");
+    assert!(scope.injected_services.contains(&"DataService".to_string()));
+}
+
+// ==========================================================================
+// DI参照（$以外のサービス名）が正しく参照登録されるか
+// ==========================================================================
+
+#[test]
+fn test_di_array_registers_references() {
+    let index = analyze(
+        r#"
+angular.module('app', [])
+.controller('RefTest', ['$scope', 'MyService', 'OtherService', function($scope, MyService, OtherService) {
+}]);
+"#,
+    );
+
+    let my_refs = index.definitions.get_references("MyService");
+    assert!(
+        !my_refs.is_empty(),
+        "MyService should have a reference registered"
+    );
+
+    let other_refs = index.definitions.get_references("OtherService");
+    assert!(
+        !other_refs.is_empty(),
+        "OtherService should have a reference registered"
+    );
+}
+
+// ==========================================================================
+// コンポーネントの定義
+// ==========================================================================
+
+#[test]
+fn test_component_definition() {
+    let index = analyze(
+        r#"
+angular.module('app', [])
+.component('userList', {
+    templateUrl: 'user-list.html',
+    controller: 'UserListCtrl',
+    bindings: {
+        users: '<',
+        onSelect: '&'
+    }
+});
+"#,
+    );
+
+    assert!(has_definition(&index, "userList", SymbolKind::Component));
+}
+
+// ==========================================================================
+// 複合テスト: sample.js フィクスチャ相当
+// ==========================================================================
+
+#[test]
+fn test_full_module_registration() {
+    let index = analyze(
+        r#"
+angular.module('myApp', ['ngRoute', 'myApp.services'])
+
+.controller('MainCtrl', ['$scope', 'UserService', function($scope, UserService) {
+    $scope.users = [];
+}])
+
+.service('UserService', ['$http', '$q', function($http, $q) {
+    this.getAll = function() {};
+}])
+
+.directive('userCard', ['UserService', function(UserService) {
+    return { restrict: 'E' };
+}])
+
+.factory('AuthService', ['$http', '$q', function($http, $q) {
+    return { login: function() {} };
+}])
+
+.constant('API_URL', 'https://api.example.com')
+
+.value('appConfig', { debug: true });
+"#,
+    );
+
+    assert!(has_definition(&index, "myApp", SymbolKind::Module));
+    assert!(has_definition(&index, "MainCtrl", SymbolKind::Controller));
+    assert!(has_definition(&index, "UserService", SymbolKind::Service));
+    assert!(has_definition(&index, "userCard", SymbolKind::Directive));
+    assert!(has_definition(&index, "AuthService", SymbolKind::Factory));
+    assert!(has_definition(&index, "API_URL", SymbolKind::Constant));
+    assert!(has_definition(&index, "appConfig", SymbolKind::Value));
+
+    // DI参照チェック
+    let user_refs = index.definitions.get_references("UserService");
+    assert!(
+        !user_refs.is_empty(),
+        "UserService should be referenced from controllers"
+    );
+}

--- a/src/index/query.rs
+++ b/src/index/query.rs
@@ -251,18 +251,25 @@ impl Index {
     pub fn resolve_template_uri(&self, template_path: &str) -> Option<Url> {
         use crate::util::normalize_template_path;
         let normalized_path = normalize_template_path(template_path);
+        let suffix = format!("/{}", normalized_path);
 
         // controller scopeのURIから検索
         for uri in self.controllers.html_controller_scope_uris() {
             let path = uri.path();
-            if path.ends_with(&format!("/{}", normalized_path))
-                || path.ends_with(&normalized_path)
-            {
+            if path.ends_with(&suffix) || path.ends_with(&normalized_path) {
                 return Some(uri);
             }
         }
 
-        // テンプレートストアで検索
+        // 解析済みHTML URIから検索
+        for uri in self.templates.analyzed_html_uris() {
+            let path = uri.path();
+            if path.ends_with(&suffix) || path.ends_with(&normalized_path) {
+                return Some(uri);
+            }
+        }
+
+        // テンプレートストアで検索（フォールバック）
         self.templates.resolve_template_uri(template_path)
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -178,6 +178,7 @@ impl Backend {
 
                     let scripts = bl_html_analyzer
                         .analyze_document_and_extract_scripts(&bl_uri, &latest_text);
+                    bl_index.templates.mark_html_analyzed(&bl_uri);
                     for script in scripts {
                         bl_analyzer.analyze_embedded_script(
                             &bl_uri,
@@ -286,6 +287,7 @@ impl Backend {
             tokio::task::spawn_blocking(move || {
                 let scripts =
                     bl_html_analyzer.analyze_document_and_extract_scripts(&bl_uri, &bl_text);
+                bl_index.templates.mark_html_analyzed(&bl_uri);
                 for script in scripts {
                     bl_analyzer
                         .analyze_embedded_script(&bl_uri, &script.source, script.line_offset);
@@ -456,6 +458,10 @@ impl Backend {
                         for (uri, content, tree) in &parsed_html_files {
                             self.html_analyzer
                                 .collect_controller_scopes_only_with_tree(uri, content, tree);
+                        }
+                        // 全HTMLファイルを解析済みとして登録
+                        for (uri, _content, _tree) in &parsed_html_files {
+                            self.index.templates.mark_html_analyzed(uri);
                         }
                     });
                 });
@@ -654,6 +660,10 @@ impl Backend {
                 for (uri, content, tree) in &parsed_html_files {
                     self.html_analyzer
                         .collect_controller_scopes_only_with_tree(uri, content, tree);
+                }
+                // 全HTMLファイルを解析済みとして登録
+                for (uri, _content, _tree) in &parsed_html_files {
+                    self.index.templates.mark_html_analyzed(uri);
                 }
             });
             s.spawn(|| {


### PR DESCRIPTION
3箇所に重複していたDI情報抽出ロジック(array/function/class/identifier分岐)を
extract_di_infoメソッドに集約。識別子の場合は変数宣言の値も探索して中身に基づき
判断するようになり、一時変数に格納されたDI配列や関数も正しく解析できるようになった。

- DiInfo構造体を新設(injected_services, has_scope, has_root_scope)
- extract_di_info: ノード種別に応じた統一的なDI情報抽出
- 不要になった_from_function_ref系メソッド3つを削除

https://claude.ai/code/session_01Tc6TcV7tA4TRs53RJMiRwo