### PR TITLE
Support factory pattern with service variable assignment

### DIFF
--- a/UNSUPPORTED_FEATURES.md
+++ b/UNSUPPORTED_FEATURES.md
@@ -4,7 +4,7 @@
 
 ---
 
-## JS側（11項目）
+## JS側（10項目）
 
 ### 1. `module.decorator()` がシンボルとして認識されない
 
@@ -39,21 +39,11 @@ angular.module('app', []).factory('UserResource', ['$resource', function($resour
 
 ---
 
-### 3. factory内 `var service = {}; service.xxx` パターンが認識されない
+### ~~3. factory内 `var service = {}; service.xxx` パターンが認識されない~~ (対応済み)
 
-`return { ... }` 形式は認識されるが、変数にオブジェクトを代入してプロパティを追加するパターンは未対応。
+~~`return { ... }` 形式は認識されるが、変数にオブジェクトを代入してプロパティを追加するパターンは未対応。~~
 
-```javascript
-angular.module('app', []).factory('SvcA', [function() {
-    var service = {};
-    service.doWork = function() {};
-    service.name = 'test';
-    return service;
-}]);
-// SvcA.doWork が Method として認識されない
-```
-
-**対応案**: factory 関数内で `return` される変数を追跡し、その変数へのプロパティ代入を Method として登録する。
+**対応済み**: `return` される変数名を `find_returned_variable_name()` で検出し、その変数へのプロパティ代入を `extract_returned_var_method()` で Method として登録するようにした。DI配列記法・直接関数渡しの両方に対応。
 
 ---
 


### PR DESCRIPTION
## Summary
This PR adds support for detecting methods and properties in AngularJS factories that use the service variable pattern (`var service = {}; service.method = ...; return service;`). Previously, only `this.method` and inline return object patterns were recognized.

## Key Changes
- **Added `find_returned_variable_name()` method**: Detects the variable name being returned from factory functions, enabling tracking of which variable holds the exported API
- **Added `extract_returned_var_method()` method**: Extracts method and property definitions assigned to the returned variable (e.g., `service.doWork = function() {}`)
- **Updated `scan_for_methods()` signature**: Now accepts an optional `returned_var` parameter to pass the returned variable name through the AST traversal
- **Enhanced method detection logic**: When scanning assignment expressions, now checks both `this.method` patterns and `returnedVar.method` patterns

## Implementation Details
- The returned variable name is detected once per factory/service function and passed down through recursive AST traversal
- Both function assignments (`service.method = function() {}`) and property assignments (`service.name = 'value'`) are now recognized as methods/properties of the service
- Works with all factory definition patterns:
  - DI array syntax: `.factory('Name', ['$dep', function($dep) {...}])`
  - Direct function syntax: `.factory('Name', function() {...})`
  - Multiple variable names (e.g., `var svc = {}` or `var service = {}`)

## Tests Added
- `test_factory_service_variable_pattern`: Basic service variable pattern
- `test_factory_service_variable_pattern_with_di`: Service variable pattern with dependency injection
- `test_factory_service_variable_pattern_without_di_array`: Service variable pattern with direct function syntax
- Updated existing `test_factory_with_return_object` test to verify the new functionality

https://claude.ai/code/session_017DNLK6P9W2diJrwLzBjAYw