### PR TITLE
Add support for $stateProvider.state() (ui-router) analysis

### DIFF
--- a/src/handler/codelens.rs
+++ b/src/handler/codelens.rs
@@ -343,6 +343,7 @@ impl CodeLensHandler {
 
         let source_label = match source {
             BindingSource::RouteProvider => "$routeProvider",
+            BindingSource::StateProvider => "$stateProvider",
             BindingSource::UibModal => "$uibModal",
             BindingSource::NgController => "ng-controller",
         };
@@ -437,6 +438,7 @@ impl CodeLensHandler {
 
         let source_label = match binding.source {
             BindingSource::RouteProvider => "$routeProvider",
+            BindingSource::StateProvider => "$stateProvider",
             BindingSource::UibModal => "$uibModal",
             BindingSource::NgController => "ng-controller",
         };

--- a/src/index/template_store.rs
+++ b/src/index/template_store.rs
@@ -63,7 +63,7 @@ impl TemplateStore {
         );
         self.template_bindings.insert(binding_key, normalized_binding);
 
-        if source == BindingSource::RouteProvider {
+        if source == BindingSource::RouteProvider || source == BindingSource::StateProvider {
             let filename = normalized_path
                 .rsplit('/')
                 .next()

--- a/src/model/template.rs
+++ b/src/model/template.rs
@@ -6,6 +6,7 @@ use tower_lsp::lsp_types::Url;
 pub enum BindingSource {
     NgController,
     RouteProvider,
+    StateProvider,
     UibModal,
 }
 

--- a/tests/angularjs_common_syntax_test.rs
+++ b/tests/angularjs_common_syntax_test.rs
@@ -1385,3 +1385,108 @@ fn test_comprehensive_html_analysis() {
     assert!(scope_refs.len() >= 5, "少なくとも5つのスコープ参照が認識されるべき (found: {})", scope_refs.len());
     assert!(local_vars.len() >= 1, "少なくとも1つのローカル変数が認識されるべき (found: {})", local_vars.len());
 }
+
+// ============================================================
+// $stateProvider.state() (ui-router) パターン
+// ============================================================
+
+#[test]
+fn test_state_provider_controller_reference() {
+    let source = r#"
+angular.module('app', []).config(['$stateProvider', function($stateProvider) {
+    $stateProvider
+        .state('home', {
+            url: '/home',
+            templateUrl: 'views/home.html',
+            controller: 'HomeController'
+        })
+        .state('about', {
+            url: '/about',
+            templateUrl: 'views/about.html',
+            controller: 'AboutController'
+        });
+}]);
+"#;
+    let index = analyze_js(source);
+    assert!(has_reference(&index, "HomeController"),
+        "$stateProvider.state()のcontroller文字列参照(HomeController)が認識されるべき");
+    assert!(has_reference(&index, "AboutController"),
+        "$stateProvider.state()のcontroller文字列参照(AboutController)が認識されるべき");
+}
+
+#[test]
+fn test_state_provider_template_binding() {
+    let source = r#"
+angular.module('app', []).config(['$stateProvider', function($stateProvider) {
+    $stateProvider
+        .state('dashboard', {
+            url: '/dashboard',
+            templateUrl: 'views/dashboard.html',
+            controller: 'DashboardController'
+        });
+}]);
+"#;
+    let index = analyze_js(source);
+    let bindings = index.templates.get_all_template_bindings();
+    let has_dashboard_binding = bindings.iter().any(|b|
+        b.template_path.contains("dashboard.html") && b.controller_name == "DashboardController"
+    );
+    assert!(has_dashboard_binding,
+        "$stateProvider.state()のテンプレートバインディングが登録されるべき");
+}
+
+#[test]
+fn test_state_provider_inline_controller() {
+    let source = r#"
+angular.module('app', []).config(['$stateProvider', function($stateProvider) {
+    $stateProvider.state('profile', {
+        url: '/profile',
+        templateUrl: 'views/profile.html',
+        controller: ['$scope', 'UserService', function($scope, UserService) {
+            $scope.user = {};
+            $scope.loadUser = function() {};
+        }]
+    });
+}]);
+"#;
+    let index = analyze_js(source);
+    assert!(has_definition(&index, "state.$scope.user", SymbolKind::ScopeProperty),
+        "$stateProvider.state()のインラインcontroller内の$scopeプロパティが認識されるべき");
+    assert!(has_definition(&index, "state.$scope.loadUser", SymbolKind::ScopeMethod),
+        "$stateProvider.state()のインラインcontroller内の$scopeメソッドが認識されるべき");
+}
+
+#[test]
+fn test_state_provider_chained_states() {
+    let source = r#"
+angular.module('app', []).config(['$stateProvider', function($stateProvider) {
+    $stateProvider
+        .state('users', {
+            url: '/users',
+            templateUrl: 'views/users.html',
+            controller: 'UsersController'
+        })
+        .state('users.detail', {
+            url: '/:id',
+            templateUrl: 'views/user-detail.html',
+            controller: 'UserDetailController'
+        })
+        .state('settings', {
+            url: '/settings',
+            templateUrl: 'views/settings.html',
+            controller: 'SettingsController'
+        });
+}]);
+"#;
+    let index = analyze_js(source);
+    assert!(has_reference(&index, "UsersController"),
+        "チェーンされた$stateProvider.state()の1番目のcontroller参照が認識されるべき");
+    assert!(has_reference(&index, "UserDetailController"),
+        "チェーンされた$stateProvider.state()の2番目のcontroller参照が認識されるべき");
+    assert!(has_reference(&index, "SettingsController"),
+        "チェーンされた$stateProvider.state()の3番目のcontroller参照が認識されるべき");
+
+    let bindings = index.templates.get_all_template_bindings();
+    assert_eq!(bindings.len(), 3,
+        "3つのテンプレートバインディングが登録されるべき");
+}


### PR DESCRIPTION
## Summary
This PR adds comprehensive support for analyzing AngularJS ui-router's `$stateProvider.state()` method, enabling the analyzer to extract controller references, template bindings, and dependency injection scopes from state configurations.

## Key Changes
- **New analyzer method**: Added `extract_state_provider_di()` and `extract_controller_di_from_state_config()` to handle state provider analysis
  - Extracts controller references from state configurations (both string references and inline controllers)
  - Supports dependency injection analysis for inline controller functions
  - Registers template bindings between templates and controllers
  
- **Model updates**: Added `StateProvider` variant to `BindingSource` enum to distinguish state provider bindings from route provider bindings

- **Code lens support**: Updated `CodeLensHandler` to display `$stateProvider` labels for state-based template bindings

- **Template store**: Extended template binding logic to treat `StateProvider` the same as `RouteProvider` for filename extraction

- **Comprehensive test coverage**: Added 4 new test cases covering:
  - String-based controller references in state configurations
  - Template binding registration
  - Inline controller functions with $scope property/method analysis
  - Chained state definitions with multiple controllers

## Implementation Details
- Follows the existing pattern used for `$routeProvider.when()` analysis
- Handles both string controller references (for symbol resolution) and inline controller functions (for DI scope analysis)
- Properly extracts function body ranges for scope tracking
- Supports method chaining on `$stateProvider` for multiple state definitions

https://claude.ai/code/session_01UUXzKtZFKz44brk9vU5Vqk