### PR TITLE
Support `that = this` alias in service/factory method detection

### DIFF
--- a/UNSUPPORTED_FEATURES.md
+++ b/UNSUPPORTED_FEATURES.md
@@ -80,18 +80,17 @@ $scope.user.email = 'a@b.com';  // 同様
 
 ---
 
-### 6. `that = this` エイリアスが認識されない
+### 6. ~~`that = this` エイリアスが認識されない~~ (対応済み)
 
-`vm = this` と `self = this` は対応済みだが、`that = this` は未対応。
+`vm = this` と `self = this` は対応済みだったが、サービス/ファクトリーのコードパスで `collect_this_aliases()` が呼ばれていなかった。
+サービス/ファクトリーの `extract_methods_from_function` でもthisエイリアス収集を行うように修正し、`that = this` を含む全エイリアスに対応。
 
 ```javascript
 angular.module('app', []).service('ThatSvc', [function() {
     var that = this;
-    that.doWork = function() {};  // 認識されない
+    that.doWork = function() {};  // ✓ ThatSvc.doWork として認識される
 }]);
 ```
-
-**対応案**: `src/analyzer/js/scope.rs` 付近の this エイリアス検出ロジックに `"that"` を追加する。
 
 ---
 

--- a/tests/angularjs_common_syntax_test.rs
+++ b/tests/angularjs_common_syntax_test.rs
@@ -287,6 +287,26 @@ angular.module('app', []).service('SimpleService', function($http) {
         "暗黙的DIサービスのメソッドが認識されるべき");
 }
 
+// --- thisエイリアスパターン (that = this) ---
+
+#[test]
+fn test_service_this_alias_that() {
+    let source = r#"
+angular.module('app', []).service('ThatSvc', [function() {
+    var that = this;
+    that.doWork = function() {};
+    that.name = 'test';
+}]);
+"#;
+    let index = analyze_js(source);
+    assert!(has_definition(&index, "ThatSvc", SymbolKind::Service),
+        "that=thisパターンのサービスが認識されるべき");
+    assert!(has_definition(&index, "ThatSvc.doWork", SymbolKind::Method),
+        "that.doWork が Method として認識されるべき");
+    assert!(has_definition(&index, "ThatSvc.name", SymbolKind::Method),
+        "that.name が Method として認識されるべき");
+}
+
 // ============================================================
 // 4. Factory定義パターン
 // ============================================================

--- a/tests/investigate_unsupported_test.rs
+++ b/tests/investigate_unsupported_test.rs
@@ -233,7 +233,7 @@ angular.module('app', []).controller('SelfCtrl', ['$http', function($http) {
         check("self = this; self.load パターン認識", has_def(&index, "SelfCtrl.load", SymbolKind::Method));
     }
 
-    // --- 11. that = this パターン ---
+    // --- 11. that = this パターン --- (対応済み)
     println!("\n--- 11. that = this パターン ---");
     {
         let source = r#"
@@ -243,7 +243,9 @@ angular.module('app', []).service('ThatSvc', [function() {
 }]);
 "#;
         let index = analyze_js(source);
-        check("that = this; that.doWork パターン認識", has_def(&index, "ThatSvc.doWork", SymbolKind::Method));
+        let result = has_def(&index, "ThatSvc.doWork", SymbolKind::Method);
+        check("that = this; that.doWork パターン認識", result);
+        assert!(result, "that = this パターンは対応済み");
     }
 
     // --- 12. component $onInit 等のライフサイクルフック ---


### PR DESCRIPTION
## Summary
Fixed an issue where the `that = this` alias pattern was not being recognized in AngularJS services and factories. While `vm = this` and `self = this` aliases were already supported, the this-alias collection logic was not being invoked in the service/factory code paths.

## Changes Made
- **Modified `src/analyzer/js/service_method.rs`**:
  - Added `collect_this_aliases()` call in both `extract_methods_from_function()` (for services) and `extract_methods_from_function_factory()` (for factories)
  - Updated `scan_for_methods()` to accept and pass through `this_aliases` parameter
  - Modified `extract_this_method()` to check if the object matches any collected this aliases, not just the literal `"this"` keyword
  
- **Updated `UNSUPPORTED_FEATURES.md`**:
  - Marked issue #6 as resolved
  - Documented the root cause: this-alias collection wasn't being called in service/factory code paths
  - Removed the proposed solution section since it's now implemented

- **Added test coverage in `tests/angularjs_common_syntax_test.rs`**:
  - New test `test_service_this_alias_that()` verifies that `that = this` pattern is correctly recognized in services
  - Tests both method and property definitions using the `that` alias

- **Updated `tests/investigate_unsupported_test.rs`**:
  - Marked the `that = this` pattern test as resolved
  - Added assertion to confirm the pattern is now properly supported

## Implementation Details
The fix ensures that when analyzing service/factory function bodies, we:
1. First collect all this-alias assignments (e.g., `var that = this`)
2. Pass these aliases to the method scanning logic
3. Recognize method assignments using any of these aliases, not just the literal `this` keyword

This brings service/factory analysis in line with the existing controller analysis behavior.

https://claude.ai/code/session_01ErmvdQ34co1CdPKyrvGeZe