### PR TITLE
Support component controller methods and lifecycle hooks

### DIFF
--- a/UNSUPPORTED_FEATURES.md
+++ b/UNSUPPORTED_FEATURES.md
@@ -94,24 +94,24 @@ angular.module('app', []).service('ThatSvc', [function() {
 
 ---
 
-### 7. component controller内の `ctrl = this` プロパティが追跡されない
+### ~~7. component controller内の `ctrl = this` プロパティが追跡されない~~ (対応済み)
 
-コンポーネントの controller 関数内でのプロパティ定義やライフサイクルフックが未対応。
+~~コンポーネントの controller 関数内でのプロパティ定義やライフサイクルフックが未対応。~~
+
+**対応済み**: `register_component_symbol()` 内で config オブジェクトの `controller` プロパティを検出し、`extract_controller_methods()` を呼び出してコンポーネント名をプレフィックスとした Method として登録するようにした。DI配列記法・直接関数渡しの両方に対応。
 
 ```javascript
 angular.module('app', []).component('lcComp', {
     template: '<div></div>',
     controller: function() {
         var ctrl = this;
-        ctrl.data = [];                        // lcComp.data として認識されない
-        ctrl.$onInit = function() {};          // ライフサイクルフック認識されない
-        ctrl.$onDestroy = function() {};
-        ctrl.$onChanges = function(changes) {};
+        ctrl.data = [];                        // ✓ lcComp.data として認識される
+        ctrl.$onInit = function() {};          // ✓ lcComp.$onInit として認識される
+        ctrl.$onDestroy = function() {};       // ✓ lcComp.$onDestroy として認識される
+        ctrl.$onChanges = function(changes) {}; // ✓ lcComp.$onChanges として認識される
     }
 });
 ```
-
-**対応案**: component の controller 関数内での `this` / エイリアスへのプロパティ代入を、コンポーネント名をプレフィックスとした Method として登録する。
 
 ---
 

--- a/tests/angularjs_common_syntax_test.rs
+++ b/tests/angularjs_common_syntax_test.rs
@@ -582,6 +582,8 @@ angular.module('app', []).component('heroList', {
     let index = analyze_js(source);
     assert!(has_definition(&index, "heroList", SymbolKind::Component),
         "インラインコントローラー付きコンポーネントが認識されるべき");
+    assert!(has_definition(&index, "heroList.$onInit", SymbolKind::Method),
+        "DI配列記法のインラインコントローラー内の$onInitが認識されるべき");
 }
 
 #[test]
@@ -602,6 +604,16 @@ angular.module('app', []).component('lifecycleDemo', {
     let index = analyze_js(source);
     assert!(has_definition(&index, "lifecycleDemo", SymbolKind::Component),
         "ライフサイクルフック付きコンポーネントが認識されるべき");
+    assert!(has_definition(&index, "lifecycleDemo.status", SymbolKind::Method),
+        "コンポーネントコントローラー内のプロパティが認識されるべき");
+    assert!(has_definition(&index, "lifecycleDemo.$onInit", SymbolKind::Method),
+        "コンポーネントの$onInitライフサイクルフックが認識されるべき");
+    assert!(has_definition(&index, "lifecycleDemo.$onDestroy", SymbolKind::Method),
+        "コンポーネントの$onDestroyライフサイクルフックが認識されるべき");
+    assert!(has_definition(&index, "lifecycleDemo.$doCheck", SymbolKind::Method),
+        "コンポーネントの$doCheckライフサイクルフックが認識されるべき");
+    assert!(has_definition(&index, "lifecycleDemo.$postLink", SymbolKind::Method),
+        "コンポーネントの$postLinkライフサイクルフックが認識されるべき");
 }
 
 // ============================================================

--- a/tests/investigate_unsupported_test.rs
+++ b/tests/investigate_unsupported_test.rs
@@ -248,7 +248,7 @@ angular.module('app', []).service('ThatSvc', [function() {
         assert!(result, "that = this パターンは対応済み");
     }
 
-    // --- 12. component $onInit 等のライフサイクルフック ---
+    // --- 12. component $onInit 等のライフサイクルフック --- (対応済み)
     println!("\n--- 12. component ライフサイクルフック認識 ---");
     {
         let source = r#"
@@ -266,10 +266,18 @@ angular.module('app', []).component('lcComp', {
 });
 "#;
         let index = analyze_js(source);
-        check("ctrl.data (コンポーネント内プロパティ)", has_def(&index, "lcComp.data", SymbolKind::Method));
-        check("ctrl.$onInit (ライフサイクルフック)", has_def(&index, "lcComp.$onInit", SymbolKind::Method));
-        check("ctrl.$onDestroy (ライフサイクルフック)", has_def(&index, "lcComp.$onDestroy", SymbolKind::Method));
-        check("ctrl.$onChanges (ライフサイクルフック)", has_def(&index, "lcComp.$onChanges", SymbolKind::Method));
+        let result_data = has_def(&index, "lcComp.data", SymbolKind::Method);
+        let result_init = has_def(&index, "lcComp.$onInit", SymbolKind::Method);
+        let result_destroy = has_def(&index, "lcComp.$onDestroy", SymbolKind::Method);
+        let result_changes = has_def(&index, "lcComp.$onChanges", SymbolKind::Method);
+        check("ctrl.data (コンポーネント内プロパティ)", result_data);
+        check("ctrl.$onInit (ライフサイクルフック)", result_init);
+        check("ctrl.$onDestroy (ライフサイクルフック)", result_destroy);
+        check("ctrl.$onChanges (ライフサイクルフック)", result_changes);
+        assert!(result_data, "component controller内の ctrl.data は対応済み");
+        assert!(result_init, "component controller内の ctrl.$onInit は対応済み");
+        assert!(result_destroy, "component controller内の ctrl.$onDestroy は対応済み");
+        assert!(result_changes, "component controller内の ctrl.$onChanges は対応済み");
     }
 
     // --- 13. provider の $get メソッド ---


### PR DESCRIPTION
## Summary
Implement support for extracting properties and lifecycle hooks defined within AngularJS component controller functions. Previously, properties and methods assigned to `this` or controller aliases within component controllers were not recognized by the analyzer.

## Changes Made
- **Added `extract_component_controller_methods()` function** in `src/analyzer/js/component.rs` to detect and extract the `controller` property from component configuration objects
- **Integrated controller method extraction** into the component registration flow by calling `extract_component_controller_methods()` from `register_component_symbol()`
- **Updated documentation** in `UNSUPPORTED_FEATURES.md` to mark feature #7 as resolved, with detailed explanation of the implementation
- **Enhanced test coverage** in `tests/angularjs_common_syntax_test.rs` to verify:
  - Inline controller methods with DI array notation
  - Component properties (e.g., `lcComp.data`)
  - Lifecycle hooks (`$onInit`, `$onDestroy`, `$doCheck`, `$postLink`)
- **Updated investigation tests** in `tests/investigate_unsupported_test.rs` with assertions confirming the feature is now supported

## Implementation Details
The solution recognizes both DI array notation and direct function syntax for component controllers:
```javascript
.component('lcComp', {
    controller: function() {
        var ctrl = this;
        ctrl.data = [];           // Now recognized as lcComp.data
        ctrl.$onInit = function() {}; // Now recognized as lcComp.$onInit
    }
})
```

Properties and methods are registered with the component name as a prefix, enabling proper symbol resolution and IDE support.

https://claude.ai/code/session_01NA9TXcasFKmdENZTgGutPH