### PR TITLE
fix: $scope補完のプレフィックス漏れと削除後の残留を修正

### DIFF
--- a/src/index/definition_store.rs
+++ b/src/index/definition_store.rs
@@ -102,7 +102,14 @@ impl DefinitionStore {
     pub fn get_reference_only_names(&self) -> Vec<String> {
         self.references
             .iter()
-            .filter(|entry| !self.definitions.contains_key(entry.key()))
+            .filter(|entry| {
+                !entry.value().is_empty()
+                    && self
+                        .definitions
+                        .get(entry.key())
+                        .map(|d| d.is_empty())
+                        .unwrap_or(true)
+            })
             .map(|entry| entry.key().clone())
             .collect()
     }
@@ -186,11 +193,24 @@ impl DefinitionStore {
     pub fn clear_document(&self, uri: &Url) {
         if let Some((_, symbols)) = self.document_symbols.remove(uri) {
             for symbol_name in symbols {
-                if let Some(mut defs) = self.definitions.get_mut(&symbol_name) {
+                let defs_empty = if let Some(mut defs) = self.definitions.get_mut(&symbol_name) {
                     defs.retain(|s| &s.uri != uri);
+                    defs.is_empty()
+                } else {
+                    false
+                };
+                if defs_empty {
+                    self.definitions.remove_if(&symbol_name, |_, v| v.is_empty());
                 }
-                if let Some(mut refs) = self.references.get_mut(&symbol_name) {
+
+                let refs_empty = if let Some(mut refs) = self.references.get_mut(&symbol_name) {
                     refs.retain(|r| &r.uri != uri);
+                    refs.is_empty()
+                } else {
+                    false
+                };
+                if refs_empty {
+                    self.references.remove_if(&symbol_name, |_, v| v.is_empty());
                 }
             }
         }
@@ -206,5 +226,101 @@ impl DefinitionStore {
 impl Default for DefinitionStore {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{Span, SymbolBuilder, SymbolKind};
+
+    fn make_uri() -> Url {
+        Url::parse("file:///test.js").unwrap()
+    }
+
+    fn make_reference(name: &str, uri: &Url) -> SymbolReference {
+        SymbolReference {
+            name: name.to_string(),
+            uri: uri.clone(),
+            span: Span::new(0, 0, 0, name.len() as u32),
+        }
+    }
+
+    fn make_definition(name: &str, uri: &Url) -> Symbol {
+        let span = Span::new(0, 0, 0, name.len() as u32);
+        SymbolBuilder::new(name.to_string(), SymbolKind::ScopeProperty, uri.clone())
+            .definition_span(span)
+            .name_span(span)
+            .build()
+    }
+
+    #[test]
+    fn clear_document_removes_empty_reference_keys() {
+        let store = DefinitionStore::new();
+        let uri = make_uri();
+
+        // 入力途中のプレフィックス参照（mo, moc, moch, mochi）を登録
+        for name in ["Ctrl.$scope.mo", "Ctrl.$scope.moc", "Ctrl.$scope.moch", "Ctrl.$scope.mochi"] {
+            store.add_reference(make_reference(name, &uri));
+        }
+
+        store.clear_document(&uri);
+
+        // 補完候補ソースとなる get_reference_only_names が空であることを確認
+        let names = store.get_reference_only_names();
+        assert!(
+            names.is_empty(),
+            "expected no reference-only names after clear, got {:?}",
+            names
+        );
+    }
+
+    #[test]
+    fn deleted_reference_does_not_resurface_in_completion() {
+        let store = DefinitionStore::new();
+        let uri = make_uri();
+
+        // ユーザが $scope.mochi を参照として書いた状態
+        store.add_reference(make_reference("Ctrl.$scope.mochi", &uri));
+        assert_eq!(store.get_reference_only_names(), vec!["Ctrl.$scope.mochi"]);
+
+        // ユーザが該当行を削除 → 再解析で clear_document が呼ばれる
+        store.clear_document(&uri);
+
+        // 再解析後、$scope.mochi はソースに無いので何も add されない
+        assert!(store.get_reference_only_names().is_empty());
+    }
+
+    #[test]
+    fn clear_document_preserves_other_uris() {
+        let store = DefinitionStore::new();
+        let uri_a = Url::parse("file:///a.js").unwrap();
+        let uri_b = Url::parse("file:///b.js").unwrap();
+
+        store.add_reference(make_reference("Ctrl.$scope.shared", &uri_a));
+        store.add_reference(make_reference("Ctrl.$scope.shared", &uri_b));
+
+        store.clear_document(&uri_a);
+
+        // uri_b の参照は残っているので、reference-only として現れる
+        let names = store.get_reference_only_names();
+        assert_eq!(names, vec!["Ctrl.$scope.shared"]);
+        assert_eq!(store.get_references("Ctrl.$scope.shared").len(), 1);
+    }
+
+    #[test]
+    fn clear_document_removes_empty_definition_keys() {
+        let store = DefinitionStore::new();
+        let uri = make_uri();
+
+        store.add_definition(make_definition("Ctrl.$scope.mochi", &uri));
+        store.add_reference(make_reference("Ctrl.$scope.other", &uri));
+
+        store.clear_document(&uri);
+
+        // 定義が空になったキーは contains_key で false を返す必要がある
+        // （これがなければ get_reference_only_names で他の reference-only も誤判定する）
+        assert!(!store.has_definition("Ctrl.$scope.mochi"));
+        assert!(store.get_reference_only_names().is_empty());
     }
 }


### PR DESCRIPTION
## Summary
`$scope.X` の補完で発生していた以下2つの不具合を修正します。

- `$scope.mochi` をタイプする途中の `mo` / `moc` / `moch` などの中間プレフィックスが補完候補に残り続ける
- `$scope.mochi` を削除しても `mochi` が補完から消えない

## 原因
`DefinitionStore::clear_document` は `retain` で `Vec` の中身を絞り込むだけで、空になった `Vec` のキーを `DashMap` から削除していませんでした。

その結果、補完候補のソースとなる `get_reference_only_names` が「空の `Vec` を持つ幽霊キー」までも返してしまい、

- 入力中に一時的に登録された各プレフィックス参照が、後続の clear で空にされてもキーとして残る
- 削除済みシンボルのキーも同様に残る

という挙動になっていました。

## Changes Made
- **`src/index/definition_store.rs`**:
  - `clear_document`: `retain` 後に空になった `Vec` のキーを `remove_if` で `DashMap` から削除
  - `get_reference_only_names`: 防御として空 `Vec` のエントリを除外し、`definitions` 側も「キー存在」ではなく「中身が空でない」を見るように変更
  - 回帰防止のためのユニットテスト4件を追加:
    - `clear_document_removes_empty_reference_keys` — プレフィックス漏れ回帰防止
    - `deleted_reference_does_not_resurface_in_completion` — 削除後の残留回帰防止
    - `clear_document_preserves_other_uris` — 別URIの参照を巻き込まないこと
    - `clear_document_removes_empty_definition_keys` — 定義側の空キーも削除されること

## Test plan
- [x] `cargo test` で既存 183 件 + 新規 4 件すべて通過
- [ ] VSCode 拡張で `$scope.foo` を入力 → 削除 → 補完候補から `foo` が消えることを目視確認
- [ ] `$scope.bar` を1文字ずつ入力中、過去のプレフィックスが補完候補に出ないことを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)