### PR TITLE
feat: component 要素の bindings 属性名を補完候補に追加

### DIFF
--- a/src/analyzer/html/expression.rs
+++ b/src/analyzer/html/expression.rs
@@ -266,6 +266,24 @@ impl HtmlAngularJsAnalyzer {
     /// 属性値の中ではfalseを返す
     /// 戻り値: Some((prefix, is_tag_name)) - prefix: 入力中の文字列, is_tag_name: タグ名位置かどうか
     pub fn get_directive_completion_context(&self, source: &str, line: u32, col: u32) -> Option<(String, bool)> {
+        self.get_directive_completion_context_with_tag(source, line, col)
+            .map(|(prefix, is_tag_name, _)| (prefix, is_tag_name))
+    }
+
+    /// `get_directive_completion_context` の拡張版。属性名位置の場合、その属性が
+    /// 属する要素のタグ名（kebab-case のまま）も返す。component bindings 補完で
+    /// 「どの component の属性を編集中か」を知るために使う。
+    ///
+    /// 戻り値: Some((prefix, is_tag_name, element_tag_name))
+    /// - prefix: 入力中の文字列
+    /// - is_tag_name: タグ名位置か（true なら element_tag_name は None）
+    /// - element_tag_name: 属性名位置の場合、要素のタグ名（kebab-case のまま、空ならNone）
+    pub fn get_directive_completion_context_with_tag(
+        &self,
+        source: &str,
+        line: u32,
+        col: u32,
+    ) -> Option<(String, bool, Option<String>)> {
         let lines: Vec<&str> = source.lines().collect();
         if (line as usize) >= lines.len() {
             return None;
@@ -315,7 +333,7 @@ impl HtmlAngularJsAnalyzer {
         // スペースがなければタグ名、あれば属性名
         if !tag_content.contains(char::is_whitespace) {
             // タグ名位置
-            Some((tag_content.to_string(), true))
+            Some((tag_content.to_string(), true, None))
         } else {
             // 属性名位置 - 最後のスペース後の文字列を取得
             // ただし `=` の後にいる場合（属性値を開始しようとしている場合）は除外
@@ -332,7 +350,14 @@ impl HtmlAngularJsAnalyzer {
                 return None;
             }
 
-            Some((attr_part.to_string(), false))
+            // 要素のタグ名を抽出 (`<` の直後から最初の空白まで)
+            let element_tag_name = tag_content
+                .split_ascii_whitespace()
+                .next()
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string());
+
+            Some((attr_part.to_string(), false, element_tag_name))
         }
     }
 }

--- a/src/handler/completion.rs
+++ b/src/handler/completion.rs
@@ -5,7 +5,7 @@ use tower_lsp::lsp_types::*;
 
 use crate::index::Index;
 use crate::model::SymbolKind;
-use crate::util::camel_to_kebab;
+use crate::util::{camel_to_kebab, kebab_to_camel};
 
 /// HTML補完候補のラベル重複を避けつつ追加するヘルパー
 fn push_unique(items: &mut Vec<CompletionItem>, seen: &mut HashSet<String>, item: CompletionItem) {
@@ -412,6 +412,64 @@ impl CompletionHandler {
         }
 
         items
+    }
+
+    /// 指定したcomponent要素の bindings を kebab-case 属性名として補完候補で返す
+    ///
+    /// 例: `.component('fooComp', { bindings: { onChange: '&', valueIn: '<' } })`
+    ///     に対し、element_tag_name="foo-comp" で呼ぶと "on-change", "value-in" が返る。
+    ///
+    /// element_tag_name: kebab-case 形式の要素名 (e.g., "foo-comp")
+    /// prefix: 入力中の属性名プレフィックス (kebab-case、空ならフィルタなし)
+    pub fn complete_component_bindings(
+        &self,
+        element_tag_name: &str,
+        prefix: &str,
+    ) -> Vec<CompletionItem> {
+        let camel_name = kebab_to_camel(element_tag_name);
+        let prefix_str = format!("{}.", camel_name);
+
+        // 当該componentが存在しない場合は空（誤った要素名で binding を提案しない）
+        let component_exists = self
+            .index
+            .definitions
+            .get_definitions(&camel_name)
+            .iter()
+            .any(|d| d.kind == SymbolKind::Component);
+        if !component_exists {
+            return Vec::new();
+        }
+
+        self.index
+            .definitions
+            .get_all_definitions()
+            .into_iter()
+            .filter(|s| s.kind == SymbolKind::ComponentBinding && s.name.starts_with(&prefix_str))
+            .filter_map(|s| {
+                let binding_name = s.name.strip_prefix(&prefix_str)?.to_string();
+                let kebab_binding = camel_to_kebab(&binding_name);
+                if !prefix.is_empty() && !kebab_binding.starts_with(prefix) {
+                    return None;
+                }
+                let detail = s
+                    .docs
+                    .clone()
+                    .map(|d| format!("{} ({})", camel_name, d))
+                    .unwrap_or_else(|| format!("{} binding", camel_name));
+                Some(CompletionItem {
+                    label: kebab_binding,
+                    kind: Some(CompletionItemKind::PROPERTY),
+                    detail: Some(detail),
+                    documentation: s.docs.clone().map(|docs| {
+                        Documentation::MarkupContent(MarkupContent {
+                            kind: MarkupKind::Markdown,
+                            value: docs,
+                        })
+                    }),
+                    ..Default::default()
+                })
+            })
+            .collect()
     }
 
     /// HTMLでのディレクティブ補完を返す

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1361,15 +1361,37 @@ impl LanguageServer for Backend {
                 let source = doc.value();
 
                 // Directive completion context
-                if let Some((prefix, is_tag_name)) =
-                    self.html_analyzer
-                        .get_directive_completion_context(source, line, col)
+                if let Some((prefix, is_tag_name, element_tag_name)) = self
+                    .html_analyzer
+                    .get_directive_completion_context_with_tag(source, line, col)
                 {
                     let handler = CompletionHandler::new(Arc::clone(&self.index));
-                    if let Some(completions) =
+                    let mut items: Vec<CompletionItem> = Vec::new();
+
+                    // 属性名位置 + 既知 component 要素 → bindings を提案
+                    if !is_tag_name {
+                        if let Some(ref tag_name) = element_tag_name {
+                            items.extend(
+                                handler.complete_component_bindings(tag_name, &prefix),
+                            );
+                        }
+                    }
+
+                    // 既存のディレクティブ補完（ng-* など）も併せて返す
+                    if let Some(CompletionResponse::Array(directive_items)) =
                         handler.complete_directives(&prefix, is_tag_name)
                     {
-                        return Ok(Some(completions));
+                        let mut seen: std::collections::HashSet<String> =
+                            items.iter().map(|i| i.label.clone()).collect();
+                        for item in directive_items {
+                            if seen.insert(item.label.clone()) {
+                                items.push(item);
+                            }
+                        }
+                    }
+
+                    if !items.is_empty() {
+                        return Ok(Some(CompletionResponse::Array(items)));
                     }
                 }
 

--- a/tests/angularjs_common_syntax_test.rs
+++ b/tests/angularjs_common_syntax_test.rs
@@ -2046,3 +2046,156 @@ fn test_ng_repeat_special_variables_only_in_scope() {
         outer_labels
     );
 }
+
+// ============================================================
+// component要素のbindings属性名補完
+// ============================================================
+
+#[test]
+fn test_component_bindings_completion_lists_bindings_for_known_element() {
+    use angularjs_lsp::handler::CompletionHandler;
+
+    let js = r#"
+angular.module('app', []).component('fooComp', {
+    template: '<div></div>',
+    bindings: {
+        valueIn: '<',
+        onChange: '&'
+    }
+});
+"#;
+    let index = analyze_js(js);
+    let handler = CompletionHandler::new(index);
+
+    let items = handler.complete_component_bindings("foo-comp", "");
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+
+    assert!(
+        labels.contains(&"value-in"),
+        "kebab-case化された 'value-in' が候補に含まれるべき (labels: {:?})",
+        labels
+    );
+    assert!(
+        labels.contains(&"on-change"),
+        "kebab-case化された 'on-change' が候補に含まれるべき (labels: {:?})",
+        labels
+    );
+}
+
+#[test]
+fn test_component_bindings_completion_filters_by_prefix() {
+    use angularjs_lsp::handler::CompletionHandler;
+
+    let js = r#"
+angular.module('app', []).component('fooComp', {
+    template: '<div></div>',
+    bindings: {
+        valueIn: '<',
+        valueOut: '<',
+        onChange: '&'
+    }
+});
+"#;
+    let index = analyze_js(js);
+    let handler = CompletionHandler::new(index);
+
+    let items = handler.complete_component_bindings("foo-comp", "val");
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+
+    assert!(
+        labels.contains(&"value-in"),
+        "プレフィックス 'val' で 'value-in' が残るべき (labels: {:?})",
+        labels
+    );
+    assert!(
+        labels.contains(&"value-out"),
+        "プレフィックス 'val' で 'value-out' が残るべき (labels: {:?})",
+        labels
+    );
+    assert!(
+        !labels.contains(&"on-change"),
+        "プレフィックス 'val' で 'on-change' は除外されるべき (labels: {:?})",
+        labels
+    );
+}
+
+#[test]
+fn test_component_bindings_completion_returns_empty_for_unknown_element() {
+    use angularjs_lsp::handler::CompletionHandler;
+
+    let js = r#"
+angular.module('app', []).component('fooComp', {
+    bindings: { valueIn: '<' }
+});
+"#;
+    let index = analyze_js(js);
+    let handler = CompletionHandler::new(index);
+
+    let items = handler.complete_component_bindings("bar-comp", "");
+    assert!(
+        items.is_empty(),
+        "未知の要素名では何も返さないべき (items: {:?})",
+        items.iter().map(|i| i.label.as_str()).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_component_bindings_completion_does_not_leak_other_components() {
+    use angularjs_lsp::handler::CompletionHandler;
+
+    let js = r#"
+angular.module('app', [])
+    .component('fooComp', { bindings: { fooName: '<' } })
+    .component('barComp', { bindings: { barName: '<' } });
+"#;
+    let index = analyze_js(js);
+    let handler = CompletionHandler::new(index);
+
+    let items = handler.complete_component_bindings("foo-comp", "");
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+
+    assert!(
+        labels.contains(&"foo-name"),
+        "fooComp 自身の binding 'foo-name' が含まれるべき (labels: {:?})",
+        labels
+    );
+    assert!(
+        !labels.contains(&"bar-name"),
+        "他コンポーネントの binding 'bar-name' は混入しないべき (labels: {:?})",
+        labels
+    );
+}
+
+#[test]
+fn test_directive_completion_context_returns_element_tag_name() {
+    use std::sync::Arc;
+    use angularjs_lsp::analyzer::html::HtmlAngularJsAnalyzer;
+    use angularjs_lsp::analyzer::js::AngularJsAnalyzer;
+    use angularjs_lsp::index::Index;
+
+    let index = Arc::new(Index::new());
+    let js_analyzer = Arc::new(AngularJsAnalyzer::new(index.clone()));
+    let html_analyzer = HtmlAngularJsAnalyzer::new(index.clone(), js_analyzer);
+
+    let html = r#"<foo-comp val></foo-comp>"#;
+    // col index: 0:'<' 1-3:foo 4:'-' 5-7:com 8:p 9:' ' 10-12:val 13:'>'
+
+    // col=13 = "val" の直後（`>` の手前）
+    let ctx = html_analyzer
+        .get_directive_completion_context_with_tag(html, 0, 13)
+        .expect("属性名位置で context が返るべき");
+    assert_eq!(ctx.0, "val", "プレフィックスは 'val'");
+    assert!(!ctx.1, "属性名位置なので is_tag_name = false");
+    assert_eq!(
+        ctx.2.as_deref(),
+        Some("foo-comp"),
+        "要素名は 'foo-comp' であるべき"
+    );
+
+    // col=4 = "foo" の直後（`-` の手前）→ タグ名位置
+    let ctx_tag = html_analyzer
+        .get_directive_completion_context_with_tag(html, 0, 4)
+        .expect("タグ名位置で context が返るべき");
+    assert!(ctx_tag.1, "タグ名位置なので is_tag_name = true");
+    assert_eq!(ctx_tag.2, None, "タグ名位置では element_tag_name は None");
+}


### PR DESCRIPTION
## Summary
`<foo-comp |>` の位置で、`fooComp` で定義された bindings (kebab-case 化済み) を補完候補として返すようにします。

```javascript
.component('fooComp', { bindings: { valueIn: '<', onChange: '&' } })
```
↓ HTMLでの `<foo-comp |>` 補完で `value-in`, `on-change` が出るようになる。

## 背景
これまで HTML 属性名位置の補完はディレクティブ名（`ng-*` 等）しか返さず、component の binding 名は一切候補にならなかった。前回の component 監査で「`ComponentBinding` シンボルは index されているが未使用」と確認していた配線です。

## Note: PR #9 への積み上げ
このPRは [PR #9 (component template completion)](https://github.com/mochi33/angularjs-lsp/pull/9) に積み上げています（base = `feat/component-template-completion`）。理由は新規 API `complete_in_html_angular_context` 周辺のリファクタを前提とするため、と新規テストでも依存があるため。

PR #10 とは独立な並行PRです。マージ順は **#9 → (#10 と #11 は独立)** が綺麗。

## Changes Made
- **`src/analyzer/html/expression.rs`**:
  - `get_directive_completion_context_with_tag` を追加 — 属性名位置の場合に要素のタグ名 (kebab-case) も返す拡張版
  - 既存の `get_directive_completion_context` は新APIへの薄いラッパとして残す（後方互換）
- **`src/handler/completion.rs`**:
  - `complete_component_bindings(element_tag_name, prefix)` を追加
  - 既知 component 名でなければ空を返す（誤検出防止）
  - kebab→camel 変換で `<foo-comp>` → `fooComp.bindingName` を引き出し、binding 名は kebab-case に再変換して候補化
- **`src/server/mod.rs`**:
  - 属性名位置で `element_tag_name` が取れたら component bindings を先頭に挿入
  - 既存の `complete_directives` 結果も併せて返し、`ng-*` 等は引き続き表示

## Test plan
- [x] 新規テスト 5件すべて通過
  - `test_component_bindings_completion_lists_bindings_for_known_element`
  - `test_component_bindings_completion_filters_by_prefix`
  - `test_component_bindings_completion_returns_empty_for_unknown_element`（誤検出防止）
  - `test_component_bindings_completion_does_not_leak_other_components`
  - `test_directive_completion_context_returns_element_tag_name`（context 拡張）
- [x] 既存テスト全て通過（合計206件）
- [ ] VSCode 拡張で `<foo-comp |>` の位置で binding 名が候補に出ることを目視確認

## 残課題（component bindings 関連の続き）
- 未知 binding 属性で warning を出す診断（component 監査 #2）
- `=` / `&` binding 属性値をスコープ参照として登録（component 監査 #3 / UNSUPPORTED #14）

🤖 Generated with [Claude Code](https://claude.com/claude-code)