### PR TITLE
chore: bring PR #10 (ng-repeat 特殊変数) into master

### DIFF
--- a/UNSUPPORTED_FEATURES.md
+++ b/UNSUPPORTED_FEATURES.md
@@ -167,20 +167,18 @@ angular.extend($scope, {
 
 ## HTML側（4項目）
 
-### 11. ng-repeat 特殊変数（$index, $first, $last, $odd, $even）が認識されない
+### ~~11. ng-repeat 特殊変数（$index, $first, $last, $odd, $even）が認識されない~~ (対応済み)
 
-ng-repeat 内で暗黙的に利用可能な特殊変数がローカル変数/スコープ参照として登録されない。
+**対応済み**: `extract_ng_repeat_variable_definitions` で ng-repeat スコープに `$index`, `$first`, `$last`, `$middle`, `$odd`, `$even` の6変数を `HtmlLocalVariableSource::NgRepeatSpecial` として自動登録するようにした。補完候補にも出るようになり、ng-repeat スコープの内側でのみ参照解決される。
 
 ```html
 <div ng-repeat="item in items">
-    {{ $index }}: {{ item.name }}         <!-- $index 未認識 -->
-    <span ng-show="$first">First!</span>  <!-- $first 未認識 -->
-    <span ng-show="$last">Last!</span>    <!-- $last 未認識 -->
-    <span ng-class="{ 'odd': $odd }">row</span>  <!-- $odd 未認識 -->
+    {{ $index }}: {{ item.name }}         <!-- ✓ $index 認識 -->
+    <span ng-show="$first">First!</span>  <!-- ✓ $first 認識 -->
+    <span ng-show="$last">Last!</span>    <!-- ✓ $last 認識 -->
+    <span ng-class="{ 'odd': $odd }">row</span>  <!-- ✓ $odd 認識 -->
 </div>
 ```
-
-**対応案**: ng-repeat 解析時に `$index`, `$first`, `$last`, `$middle`, `$odd`, `$even` をローカル変数として自動登録する。
 
 ---
 

--- a/src/analyzer/html/local_variable.rs
+++ b/src/analyzer/html/local_variable.rs
@@ -8,7 +8,13 @@ use tree_sitter::Node;
 use super::directives::is_ng_directive;
 use super::variable_parser::{parse_ng_init_expression, parse_ng_repeat_expression};
 use super::HtmlAngularJsAnalyzer;
-use crate::model::{HtmlLocalVariable, HtmlLocalVariableReference};
+use crate::model::{HtmlLocalVariable, HtmlLocalVariableReference, HtmlLocalVariableSource};
+
+/// ng-repeat スコープで暗黙に利用可能な特殊変数
+/// https://docs.angularjs.org/api/ng/directive/ngRepeat
+const NG_REPEAT_SPECIAL_VARS: &[&str] = &[
+    "$index", "$first", "$last", "$middle", "$even", "$odd",
+];
 
 impl HtmlAngularJsAnalyzer {
     /// ローカル変数定義を収集（Pass 4a）
@@ -79,6 +85,36 @@ impl HtmlAngularJsAnalyzer {
                             let value_start_line = value_node.start_position().row as usize;
                             let value_byte_col = value_node.start_position().column + 1;
                             let value_start_col = self.byte_col_to_utf16_col(source, value_start_line, value_byte_col);
+
+                            // 特殊変数（$index, $first, ...）をng-repeat属性名の位置で登録
+                            // 「定義位置」がソース上に無いので、ng-repeat属性名スパンを定義位置として使う
+                            let attr_name_start_line = name_node.start_position().row as u32;
+                            let attr_name_start_byte_col = name_node.start_position().column;
+                            let attr_name_end_byte_col = name_node.end_position().column;
+                            let attr_name_start_col = self.byte_col_to_utf16_col(
+                                source,
+                                attr_name_start_line as usize,
+                                attr_name_start_byte_col,
+                            );
+                            let attr_name_end_col = self.byte_col_to_utf16_col(
+                                source,
+                                attr_name_start_line as usize,
+                                attr_name_end_byte_col,
+                            );
+                            for special in NG_REPEAT_SPECIAL_VARS {
+                                let variable = HtmlLocalVariable {
+                                    name: (*special).to_string(),
+                                    source: HtmlLocalVariableSource::NgRepeatSpecial,
+                                    uri: uri.clone(),
+                                    scope_start_line,
+                                    scope_end_line,
+                                    name_start_line: attr_name_start_line,
+                                    name_start_col: attr_name_start_col,
+                                    name_end_line: attr_name_start_line,
+                                    name_end_col: attr_name_end_col,
+                                };
+                                self.index.html.add_html_local_variable(variable);
+                            }
 
                             // 共通パーサーを使用
                             let parsed_vars = parse_ng_repeat_expression(value);

--- a/src/handler/hover.rs
+++ b/src/handler/hover.rs
@@ -212,6 +212,7 @@ impl HoverHandler {
             HtmlLocalVariableSource::NgInit => "ng-init",
             HtmlLocalVariableSource::NgRepeatIterator => "ng-repeat iterator",
             HtmlLocalVariableSource::NgRepeatKeyValue => "ng-repeat key/value",
+            HtmlLocalVariableSource::NgRepeatSpecial => "ng-repeat special",
         };
 
         let reference_count = self

--- a/src/model/html.rs
+++ b/src/model/html.rs
@@ -29,6 +29,9 @@ pub enum HtmlLocalVariableSource {
     NgRepeatIterator,
     /// ng-repeat="(key, value) in obj" -> "key", "value"
     NgRepeatKeyValue,
+    /// ng-repeat スコープで暗黙に利用可能な特殊変数
+    /// ($index, $first, $last, $middle, $odd, $even)
+    NgRepeatSpecial,
 }
 
 impl HtmlLocalVariableSource {
@@ -37,6 +40,7 @@ impl HtmlLocalVariableSource {
             HtmlLocalVariableSource::NgInit => "ng-init",
             HtmlLocalVariableSource::NgRepeatIterator => "ng-repeat",
             HtmlLocalVariableSource::NgRepeatKeyValue => "ng-repeat",
+            HtmlLocalVariableSource::NgRepeatSpecial => "ng-repeat (special)",
         }
     }
 }

--- a/tests/angularjs_common_syntax_test.rs
+++ b/tests/angularjs_common_syntax_test.rs
@@ -1920,3 +1920,129 @@ angular.module('app', []).controller('FooCtrl', ['$scope', function($scope) {
         labels
     );
 }
+
+// ============================================================
+// ng-repeat 特殊変数 ($index, $first, $last, $middle, $odd, $even)
+// ============================================================
+
+#[test]
+fn test_ng_repeat_special_variables_registered() {
+    let html = r#"
+<div ng-repeat="item in items">
+    <span>{{ $index }}: {{ item.name }}</span>
+</div>
+"#;
+    let index = analyze_html("", html);
+    let html_uri = Url::parse("file:///test.html").unwrap();
+    let local_vars = index.html.get_all_local_variables(&html_uri);
+    let names: Vec<&str> = local_vars.iter().map(|v| v.name.as_str()).collect();
+
+    for special in &["$index", "$first", "$last", "$middle", "$odd", "$even"] {
+        assert!(
+            names.contains(special),
+            "ng-repeat スコープで {} がローカル変数として登録されるべき (names: {:?})",
+            special,
+            names
+        );
+    }
+    // 通常のループ変数も健在
+    assert!(
+        names.contains(&"item"),
+        "ループ変数 'item' も登録されているべき (names: {:?})",
+        names
+    );
+}
+
+#[test]
+fn test_ng_repeat_special_variables_resolved_as_references() {
+    use angularjs_lsp::model::HtmlLocalVariableSource;
+
+    // $index などが参照として解決されること（スコープ参照ではなくローカル変数参照になる）
+    let html = r#"
+<div ng-repeat="item in items">
+    <span ng-show="$first">First!</span>
+    <span ng-class="{ 'odd': $odd }">{{ $index }}</span>
+</div>
+"#;
+    let index = analyze_html("", html);
+    let html_uri = Url::parse("file:///test.html").unwrap();
+
+    // ローカル変数 source が NgRepeatSpecial であることを確認
+    let local_vars = index.html.get_all_local_variables(&html_uri);
+    let index_var = local_vars
+        .iter()
+        .find(|v| v.name == "$index")
+        .expect("$index が登録されているべき");
+    assert_eq!(
+        index_var.source,
+        HtmlLocalVariableSource::NgRepeatSpecial,
+        "$index は NgRepeatSpecial として記録されるべき"
+    );
+
+    // 参照（HtmlLocalVariableReference）として登録されていること
+    let refs = index.html.get_all_local_variable_references_for_uri(&html_uri);
+    let ref_names: Vec<&str> = refs.iter().map(|r| r.variable_name.as_str()).collect();
+    assert!(
+        ref_names.contains(&"$index"),
+        "$index への参照が登録されるべき (ref_names: {:?})",
+        ref_names
+    );
+    assert!(
+        ref_names.contains(&"$first"),
+        "$first への参照が登録されるべき (ref_names: {:?})",
+        ref_names
+    );
+}
+
+#[test]
+fn test_ng_repeat_special_variables_in_completion() {
+    use angularjs_lsp::handler::CompletionHandler;
+
+    let html = r#"
+<div ng-repeat="item in items">
+    {{ }}
+</div>
+"#;
+    let index = analyze_html("", html);
+    let handler = CompletionHandler::new(index);
+    let html_uri = Url::parse("file:///test.html").unwrap();
+
+    // ng-repeat スコープ内（行2 = `<div ng-repeat=...>` の中）で補完
+    let items = handler.complete_in_html_angular_context(&html_uri, 2);
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+
+    for special in &["$index", "$first", "$last", "$middle", "$odd", "$even"] {
+        assert!(
+            labels.contains(special),
+            "ng-repeat スコープ内の補完候補に {} が含まれるべき (labels: {:?})",
+            special,
+            labels
+        );
+    }
+}
+
+#[test]
+fn test_ng_repeat_special_variables_only_in_scope() {
+    // ng-repeat の外側では $index 等は出ないこと
+    use angularjs_lsp::handler::CompletionHandler;
+
+    let html = r#"
+<div>
+    {{ }}
+    <div ng-repeat="item in items">{{ item }}</div>
+</div>
+"#;
+    let index = analyze_html("", html);
+    let handler = CompletionHandler::new(index);
+    let html_uri = Url::parse("file:///test.html").unwrap();
+
+    // 行2 = 外側の {{ }} の位置（ng-repeatの前）
+    let items_outer = handler.complete_in_html_angular_context(&html_uri, 2);
+    let outer_labels: Vec<&str> =
+        items_outer.iter().map(|i| i.label.as_str()).collect();
+    assert!(
+        !outer_labels.contains(&"$index"),
+        "ng-repeat の外側では $index は補完候補に出ないべき (labels: {:?})",
+        outer_labels
+    );
+}

--- a/tests/investigate_unsupported_test.rs
+++ b/tests/investigate_unsupported_test.rs
@@ -571,6 +571,11 @@ angular.module('app', []).controller('SpecialVarCtrl', ['$scope', function($scop
         check("ng-repeat $first 特殊変数", has_first);
         check("ng-repeat $last 特殊変数", has_last);
         check("ng-repeat $odd 特殊変数", has_odd);
+        // 対応済みであることを assert（回帰防止）
+        assert!(
+            has_index && has_first && has_last && has_odd,
+            "ng-repeat 特殊変数 ($index, $first, $last, $odd) は全てローカル変数として登録されているべき"
+        );
     }
 
     // --- 4. ng-repeat as (aliasAs) ---


### PR DESCRIPTION
## Summary
[PR #10](https://github.com/mochi33/angularjs-lsp/pull/10) (ng-repeat 特殊変数) は **MERGED** とマークされていますが、実際には PR #9 のブランチ (`feat/component-template-completion`) にマージされたまま master まで到達していませんでした。

このPRはその孤立したコミットを master に取り込みます。

## 経緯
- 15:28: PR #9 を master にマージ
- 16:08: PR #10 を `feat/component-template-completion` にマージ（base が PR #9 のブランチのままだったため）

その結果、master には PR #10 の作業 (`731c2d5 feat: ng-repeat の特殊変数...` と `970f7c0 Merge pull request #10`) が含まれていない状態でした。

## Diff
PR #10 と同じ内容です（`feat/component-template-completion` ブランチの PR #9 マージ後の差分）。

```
UNSUPPORTED_FEATURES.md               |  14 ++--
src/analyzer/html/local_variable.rs   |  38 +++++++++-
src/handler/hover.rs                  |   1 +
src/model/html.rs                     |   4 ++
tests/angularjs_common_syntax_test.rs | 126 ++++++++++++++++++++++++++++++++++
tests/investigate_unsupported_test.rs |   5 ++
```

## Test plan
- [x] `cargo test` 全件通過済み（PR #10 マージ時に確認済み）

## Note
このPRをマージ後、`feat/component-template-completion` ブランチは削除しても問題ありません。今後は短命ブランチを必ず master ベースに切るのが安全です。