### PR TITLE
feat: $mdDialog.show のテンプレート/コントローラーバインディングに対応

### DIFF
--- a/src/analyzer/js/component.rs
+++ b/src/analyzer/js/component.rs
@@ -21,7 +21,8 @@ impl AngularJsAnalyzer {
     /// - `.filter('Name', ...)` - フィルター定義
     /// - `.constant('Name', ...)` - 定数定義
     /// - `.value('Name', ...)` - 値定義
-    /// - `$uibModal.open({...})` - モーダルバインディング
+    /// - `$uibModal.open({...})` - UI Bootstrap モーダルバインディング
+    /// - `$mdDialog.show({...})` - Angular Material ダイアログバインディング
     pub(super) fn analyze_call_expression(&self, node: Node, source: &str, uri: &Url, ctx: &mut AnalyzerContext) {
         if let Some(callee) = node.child_by_field_name("function") {
             let callee_text = self.node_text(callee, source);
@@ -44,6 +45,7 @@ impl AngularJsAnalyzer {
                         "constant" => self.extract_component_definition(node, source, uri, SymbolKind::Constant, ctx),
                         "value" => self.extract_component_definition(node, source, uri, SymbolKind::Value, ctx),
                         "open" => self.extract_modal_binding(node, callee, source, uri),
+                        "show" => self.extract_md_dialog_binding(node, callee, source, uri),
                         "config" | "run" => self.extract_run_config_di(node, source, ctx),
                         "when" | "otherwise" => self.extract_route_when_di(node, source, uri, ctx),
                         "state" => self.extract_state_provider_di(node, source, uri, ctx),
@@ -76,9 +78,47 @@ impl AngularJsAnalyzer {
         }
     }
 
+    /// $mdDialog.show({controller, templateUrl}) からテンプレートバインディングを抽出
+    ///
+    /// 認識パターン:
+    /// ```javascript
+    /// $mdDialog.show({
+    ///     controller: 'EditDialogCtrl',
+    ///     templateUrl: 'templates/edit-dialog.html'
+    /// });
+    /// ```
+    ///
+    /// $mdDialog.confirm() / $mdDialog.alert() などのプリセットビルダーは
+    /// オブジェクト引数を取らないため自動的にスキップされる。
+    fn extract_md_dialog_binding(&self, node: Node, callee: Node, source: &str, uri: &Url) {
+        // オブジェクトが $mdDialog かチェック
+        if let Some(object) = callee.child_by_field_name("object") {
+            let obj_text = self.node_text(object, source);
+            if !obj_text.ends_with("$mdDialog") && !obj_text.ends_with("mdDialog") {
+                return;
+            }
+        } else {
+            return;
+        }
+
+        // 引数からオブジェクトを取得
+        if let Some(args) = node.child_by_field_name("arguments") {
+            if let Some(first_arg) = args.named_child(0) {
+                if first_arg.kind() == "object" {
+                    self.extract_template_binding_from_object(first_arg, source, uri, BindingSource::MdDialog);
+                }
+            }
+        }
+    }
+
     /// JSオブジェクトからcontrollerとtemplateUrlを抽出してバインディングを登録
+    ///
+    /// controller が文字列の場合は controller シンボルへの参照も登録する
+    /// （$routeProvider/$stateProvider 系は別経路でも参照登録するが、重複は
+    /// definition_store 側で URI+位置でデデュープされる）
     fn extract_template_binding_from_object(&self, obj_node: Node, source: &str, uri: &Url, binding_source: BindingSource) {
         let mut controller_name: Option<String> = None;
+        let mut controller_value_node: Option<Node> = None;
         let mut template_url: Option<String> = None;
         let mut template_url_line: Option<u32> = None;
 
@@ -95,6 +135,7 @@ impl AngularJsAnalyzer {
                             "controller" => {
                                 if value.kind() == "string" {
                                     controller_name = Some(self.extract_string_value(value, source));
+                                    controller_value_node = Some(value);
                                 }
                             }
                             "templateUrl" => {
@@ -108,6 +149,23 @@ impl AngularJsAnalyzer {
                     }
                 }
             }
+        }
+
+        // controller が文字列で指定されているなら参照を登録
+        if let (Some(name), Some(value_node)) = (controller_name.as_ref(), controller_value_node) {
+            let start = value_node.start_position();
+            let end = value_node.end_position();
+            let reference = SymbolReference {
+                name: name.clone(),
+                uri: uri.clone(),
+                span: Span::new(
+                    self.offset_line(start.row as u32),
+                    start.column as u32,
+                    self.offset_line(end.row as u32),
+                    end.column as u32,
+                ),
+            };
+            self.index.definitions.add_reference(reference);
         }
 
         // 両方揃っていればバインディングを登録

--- a/src/handler/codelens.rs
+++ b/src/handler/codelens.rs
@@ -345,6 +345,7 @@ impl CodeLensHandler {
             BindingSource::RouteProvider => "$routeProvider",
             BindingSource::StateProvider => "$stateProvider",
             BindingSource::UibModal => "$uibModal",
+            BindingSource::MdDialog => "$mdDialog",
             BindingSource::NgController => "ng-controller",
         };
 
@@ -440,6 +441,7 @@ impl CodeLensHandler {
             BindingSource::RouteProvider => "$routeProvider",
             BindingSource::StateProvider => "$stateProvider",
             BindingSource::UibModal => "$uibModal",
+            BindingSource::MdDialog => "$mdDialog",
             BindingSource::NgController => "ng-controller",
         };
 

--- a/src/model/template.rs
+++ b/src/model/template.rs
@@ -8,6 +8,7 @@ pub enum BindingSource {
     RouteProvider,
     StateProvider,
     UibModal,
+    MdDialog,
 }
 
 /// HTMLテンプレートとコントローラーのバインディング

--- a/tests/angularjs_common_syntax_test.rs
+++ b/tests/angularjs_common_syntax_test.rs
@@ -2199,3 +2199,113 @@ fn test_directive_completion_context_returns_element_tag_name() {
     assert!(ctx_tag.1, "タグ名位置なので is_tag_name = true");
     assert_eq!(ctx_tag.2, None, "タグ名位置では element_tag_name は None");
 }
+
+// ============================================================
+// $mdDialog.show のテンプレート/コントローラーバインディング
+// ============================================================
+
+#[test]
+fn test_md_dialog_template_binding() {
+    use angularjs_lsp::model::BindingSource;
+
+    let source = r#"
+angular.module('app', []).controller('DialogCtrl', ['$mdDialog', function($mdDialog) {
+    $mdDialog.show({
+        controller: 'EditDialogCtrl',
+        templateUrl: 'templates/edit-dialog.html'
+    });
+}]);
+"#;
+    let index = analyze_js(source);
+    let bindings = index.templates.get_all_template_bindings();
+    let dialog_binding = bindings
+        .iter()
+        .find(|b| b.template_path.contains("edit-dialog.html"))
+        .expect("$mdDialog.show のテンプレートバインディングが登録されるべき");
+
+    assert_eq!(dialog_binding.controller_name, "EditDialogCtrl");
+    assert_eq!(
+        dialog_binding.source,
+        BindingSource::MdDialog,
+        "BindingSource は MdDialog であるべき"
+    );
+}
+
+#[test]
+fn test_md_dialog_controller_reference_registered() {
+    let source = r#"
+angular.module('app', []).controller('PageCtrl', ['$mdDialog', function($mdDialog) {
+    $mdDialog.show({
+        controller: 'ConfirmDialogCtrl',
+        templateUrl: 'templates/confirm.html'
+    });
+}]);
+"#;
+    let index = analyze_js(source);
+    assert!(
+        has_reference(&index, "ConfirmDialogCtrl"),
+        "$mdDialog.show の controller 参照が登録されるべき"
+    );
+}
+
+#[test]
+fn test_md_dialog_show_without_template_does_not_register() {
+    // $mdDialog.confirm() / $mdDialog.alert() などプリセットビルダーは
+    // show() ではないため対象外。show() でもオブジェクト引数を取らないものは無視。
+    let source = r#"
+angular.module('app', []).controller('PageCtrl', ['$mdDialog', function($mdDialog) {
+    $mdDialog.show($mdDialog.confirm().title('確認'));
+}]);
+"#;
+    let index = analyze_js(source);
+    let bindings = index.templates.get_all_template_bindings();
+    assert!(
+        bindings.is_empty(),
+        "オブジェクト引数を取らない $mdDialog.show は無視されるべき (got: {:?})",
+        bindings.iter().map(|b| &b.template_path).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_other_show_calls_do_not_register_md_dialog_binding() {
+    // $mdDialog 以外の .show() 呼び出しは無視されるべき
+    let source = r#"
+angular.module('app', []).controller('PageCtrl', ['$scope', function($scope) {
+    someOtherService.show({
+        controller: 'NotADialogCtrl',
+        templateUrl: 'templates/not-a-dialog.html'
+    });
+}]);
+"#;
+    let index = analyze_js(source);
+    let bindings = index.templates.get_all_template_bindings();
+    assert!(
+        bindings.is_empty(),
+        "$mdDialog 以外の .show() は無視されるべき (got: {:?})",
+        bindings.iter().map(|b| &b.template_path).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_md_dialog_aliased_via_di() {
+    // DI で受けた $mdDialog の別名（mdDialog 等）も認識する
+    use angularjs_lsp::model::BindingSource;
+
+    let source = r#"
+angular.module('app', []).controller('PageCtrl', function() {
+    var mdDialog = angular.injector(['ng', 'material.components.dialog']).get('$mdDialog');
+    mdDialog.show({
+        controller: 'AliasedDialogCtrl',
+        templateUrl: 'templates/aliased.html'
+    });
+});
+"#;
+    let index = analyze_js(source);
+    let bindings = index.templates.get_all_template_bindings();
+    let binding = bindings
+        .iter()
+        .find(|b| b.template_path.contains("aliased.html"))
+        .expect("mdDialog (エイリアス) からも binding を抽出すべき");
+    assert_eq!(binding.controller_name, "AliasedDialogCtrl");
+    assert_eq!(binding.source, BindingSource::MdDialog);
+}


### PR DESCRIPTION
## Summary
Angular Material の `$mdDialog.show({ controller, templateUrl })` をテンプレートバインディングとして認識するようにします。`$uibModal.open` と同等の機能（双方向ジャンプ・Code Lens 表示・controller 文字列の go-to-definition）が効くようになります。

```javascript
$mdDialog.show({
    controller: 'EditDialogCtrl',  // ← go-to-definition で定義へジャンプ
    templateUrl: 'templates/edit-dialog.html'  // ← Code Lens で template と紐付け表示
});
```

## 背景
直前の controller↔template バインディング監査で、`BindingSource::UibModal` はあるが `MdDialog` は無いと確認していたピース。Material Design を使う AngularJS プロジェクトで需要のあるパターンです。

## Changes Made
- **`src/model/template.rs`**: `BindingSource` に `MdDialog` variant を追加
- **`src/analyzer/js/component.rs`**:
  - `.show()` の dispatch を `analyze_call_expression` に追加
  - `extract_md_dialog_binding` を追加（`$mdDialog` または `mdDialog` エイリアスにマッチ、第1引数がオブジェクトの場合のみ binding 抽出）
  - `extract_template_binding_from_object` に「controller が文字列なら参照を登録」処理を追加
    - これにより `$uibModal` の controller 文字列も自動的に参照登録されるようになる（副次的改善）
    - `$routeProvider`/`$stateProvider` は別経路でも参照を登録するが、`definition_store` の URI+位置デデュープで安全に共存
- **`src/handler/codelens.rs`**: `MdDialog` のラベル `"$mdDialog"` を追加

`$mdDialog.confirm()` / `$mdDialog.alert()` のプリセットビルダーはオブジェクト引数を取らないため、自動的にスキップされます。

## Test plan
- [x] 新規テスト 5件すべて通過
  - `test_md_dialog_template_binding`（バインディング登録 + `BindingSource::MdDialog` 確認）
  - `test_md_dialog_controller_reference_registered`（go-to-definition 用の参照登録）
  - `test_md_dialog_show_without_template_does_not_register`（プリセットビルダー無視）
  - `test_other_show_calls_do_not_register_md_dialog_binding`（他サービスの `.show()` 無視）
  - `test_md_dialog_aliased_via_di`（DI で受けた `mdDialog` エイリアスも認識）
- [x] 既存テスト全て通過（合計215件）
- [ ] 実プロジェクトで `$mdDialog.show({...})` の controller/templateUrl から目的位置へジャンプできることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)