### PR TITLE
feat: $mdBottomSheet.show のテンプレート/コントローラーバインディングに対応

### DIFF
--- a/src/analyzer/js/component.rs
+++ b/src/analyzer/js/component.rs
@@ -23,6 +23,7 @@ impl AngularJsAnalyzer {
     /// - `.value('Name', ...)` - 値定義
     /// - `$uibModal.open({...})` - UI Bootstrap モーダルバインディング
     /// - `$mdDialog.show({...})` - Angular Material ダイアログバインディング
+    /// - `$mdBottomSheet.show({...})` - Angular Material ボトムシートバインディング
     pub(super) fn analyze_call_expression(&self, node: Node, source: &str, uri: &Url, ctx: &mut AnalyzerContext) {
         if let Some(callee) = node.child_by_field_name("function") {
             let callee_text = self.node_text(callee, source);
@@ -45,7 +46,7 @@ impl AngularJsAnalyzer {
                         "constant" => self.extract_component_definition(node, source, uri, SymbolKind::Constant, ctx),
                         "value" => self.extract_component_definition(node, source, uri, SymbolKind::Value, ctx),
                         "open" => self.extract_modal_binding(node, callee, source, uri),
-                        "show" => self.extract_md_dialog_binding(node, callee, source, uri),
+                        "show" => self.extract_material_show_binding(node, callee, source, uri),
                         "config" | "run" => self.extract_run_config_di(node, source, ctx),
                         "when" | "otherwise" => self.extract_route_when_di(node, source, uri, ctx),
                         "state" => self.extract_state_provider_di(node, source, uri, ctx),
@@ -78,7 +79,7 @@ impl AngularJsAnalyzer {
         }
     }
 
-    /// $mdDialog.show({controller, templateUrl}) からテンプレートバインディングを抽出
+    /// Angular Material の .show({controller, templateUrl}) からテンプレートバインディングを抽出
     ///
     /// 認識パターン:
     /// ```javascript
@@ -86,26 +87,36 @@ impl AngularJsAnalyzer {
     ///     controller: 'EditDialogCtrl',
     ///     templateUrl: 'templates/edit-dialog.html'
     /// });
+    /// $mdBottomSheet.show({
+    ///     controller: 'OptionsSheetCtrl',
+    ///     templateUrl: 'templates/options-sheet.html'
+    /// });
     /// ```
     ///
-    /// $mdDialog.confirm() / $mdDialog.alert() などのプリセットビルダーは
+    /// オブジェクトが `$mdDialog` / `$mdBottomSheet` (および DI で受けた
+    /// `mdDialog` / `mdBottomSheet` エイリアス) の場合のみマッチ。
+    ///
+    /// `$mdDialog.confirm()` / `$mdDialog.alert()` のプリセットビルダーは
     /// オブジェクト引数を取らないため自動的にスキップされる。
-    fn extract_md_dialog_binding(&self, node: Node, callee: Node, source: &str, uri: &Url) {
-        // オブジェクトが $mdDialog かチェック
-        if let Some(object) = callee.child_by_field_name("object") {
+    fn extract_material_show_binding(&self, node: Node, callee: Node, source: &str, uri: &Url) {
+        let binding_source = if let Some(object) = callee.child_by_field_name("object") {
             let obj_text = self.node_text(object, source);
-            if !obj_text.ends_with("$mdDialog") && !obj_text.ends_with("mdDialog") {
+            if obj_text.ends_with("$mdDialog") || obj_text.ends_with("mdDialog") {
+                BindingSource::MdDialog
+            } else if obj_text.ends_with("$mdBottomSheet") || obj_text.ends_with("mdBottomSheet") {
+                BindingSource::MdBottomSheet
+            } else {
                 return;
             }
         } else {
             return;
-        }
+        };
 
         // 引数からオブジェクトを取得
         if let Some(args) = node.child_by_field_name("arguments") {
             if let Some(first_arg) = args.named_child(0) {
                 if first_arg.kind() == "object" {
-                    self.extract_template_binding_from_object(first_arg, source, uri, BindingSource::MdDialog);
+                    self.extract_template_binding_from_object(first_arg, source, uri, binding_source);
                 }
             }
         }

--- a/src/handler/codelens.rs
+++ b/src/handler/codelens.rs
@@ -346,6 +346,7 @@ impl CodeLensHandler {
             BindingSource::StateProvider => "$stateProvider",
             BindingSource::UibModal => "$uibModal",
             BindingSource::MdDialog => "$mdDialog",
+            BindingSource::MdBottomSheet => "$mdBottomSheet",
             BindingSource::NgController => "ng-controller",
         };
 
@@ -442,6 +443,7 @@ impl CodeLensHandler {
             BindingSource::StateProvider => "$stateProvider",
             BindingSource::UibModal => "$uibModal",
             BindingSource::MdDialog => "$mdDialog",
+            BindingSource::MdBottomSheet => "$mdBottomSheet",
             BindingSource::NgController => "ng-controller",
         };
 

--- a/src/model/template.rs
+++ b/src/model/template.rs
@@ -9,6 +9,7 @@ pub enum BindingSource {
     StateProvider,
     UibModal,
     MdDialog,
+    MdBottomSheet,
 }
 
 /// HTMLテンプレートとコントローラーのバインディング

--- a/tests/angularjs_common_syntax_test.rs
+++ b/tests/angularjs_common_syntax_test.rs
@@ -2287,6 +2287,101 @@ angular.module('app', []).controller('PageCtrl', ['$scope', function($scope) {
 }
 
 #[test]
+fn test_md_bottom_sheet_template_binding() {
+    use angularjs_lsp::model::BindingSource;
+
+    let source = r#"
+angular.module('app', []).controller('PageCtrl', ['$mdBottomSheet', function($mdBottomSheet) {
+    $mdBottomSheet.show({
+        controller: 'OptionsSheetCtrl',
+        templateUrl: 'templates/options-sheet.html'
+    });
+}]);
+"#;
+    let index = analyze_js(source);
+    let bindings = index.templates.get_all_template_bindings();
+    let binding = bindings
+        .iter()
+        .find(|b| b.template_path.contains("options-sheet.html"))
+        .expect("$mdBottomSheet.show のテンプレートバインディングが登録されるべき");
+
+    assert_eq!(binding.controller_name, "OptionsSheetCtrl");
+    assert_eq!(
+        binding.source,
+        BindingSource::MdBottomSheet,
+        "BindingSource は MdBottomSheet であるべき"
+    );
+}
+
+#[test]
+fn test_md_bottom_sheet_controller_reference_registered() {
+    let source = r#"
+angular.module('app', []).controller('PageCtrl', ['$mdBottomSheet', function($mdBottomSheet) {
+    $mdBottomSheet.show({
+        controller: 'ShareSheetCtrl',
+        templateUrl: 'templates/share-sheet.html'
+    });
+}]);
+"#;
+    let index = analyze_js(source);
+    assert!(
+        has_reference(&index, "ShareSheetCtrl"),
+        "$mdBottomSheet.show の controller 参照が登録されるべき"
+    );
+}
+
+#[test]
+fn test_md_bottom_sheet_aliased_via_di() {
+    use angularjs_lsp::model::BindingSource;
+
+    let source = r#"
+angular.module('app', []).controller('PageCtrl', function() {
+    var mdBottomSheet = angular.injector(['ng', 'material.components.bottomSheet']).get('$mdBottomSheet');
+    mdBottomSheet.show({
+        controller: 'AliasedSheetCtrl',
+        templateUrl: 'templates/aliased-sheet.html'
+    });
+});
+"#;
+    let index = analyze_js(source);
+    let bindings = index.templates.get_all_template_bindings();
+    let binding = bindings
+        .iter()
+        .find(|b| b.template_path.contains("aliased-sheet.html"))
+        .expect("mdBottomSheet (エイリアス) からも binding を抽出すべき");
+    assert_eq!(binding.controller_name, "AliasedSheetCtrl");
+    assert_eq!(binding.source, BindingSource::MdBottomSheet);
+}
+
+#[test]
+fn test_md_dialog_and_md_bottom_sheet_distinguished() {
+    // 同一ファイル内に両方が存在しても BindingSource で区別されること
+    use angularjs_lsp::model::BindingSource;
+
+    let source = r#"
+angular.module('app', []).controller('MixCtrl', ['$mdDialog', '$mdBottomSheet',
+    function($mdDialog, $mdBottomSheet) {
+        $mdDialog.show({ controller: 'DialogA', templateUrl: 'a.html' });
+        $mdBottomSheet.show({ controller: 'SheetB', templateUrl: 'b.html' });
+    }]);
+"#;
+    let index = analyze_js(source);
+    let bindings = index.templates.get_all_template_bindings();
+
+    let a = bindings
+        .iter()
+        .find(|b| b.template_path.ends_with("a.html"))
+        .expect("a.html のバインディングがあるべき");
+    let b = bindings
+        .iter()
+        .find(|b| b.template_path.ends_with("b.html"))
+        .expect("b.html のバインディングがあるべき");
+
+    assert_eq!(a.source, BindingSource::MdDialog);
+    assert_eq!(b.source, BindingSource::MdBottomSheet);
+}
+
+#[test]
 fn test_md_dialog_aliased_via_di() {
     // DI で受けた $mdDialog の別名（mdDialog 等）も認識する
     use angularjs_lsp::model::BindingSource;


### PR DESCRIPTION
## Summary
[PR #13](https://github.com/mochi33/angularjs-lsp/pull/13) (`$mdDialog`) と同じパターンで Angular Material の `$mdBottomSheet.show({ controller, templateUrl })` をテンプレートバインディングとして認識するようにします。

```javascript
$mdBottomSheet.show({
    controller: 'OptionsSheetCtrl',  // ← go-to-definition 可
    templateUrl: 'templates/options-sheet.html'  // ← Code Lens 表示
});
```

## Note: PR #13 への積み上げ
このPRは PR #13 に積み上げています（base = `feat/md-dialog-binding`）。`extract_md_dialog_binding` を `extract_material_show_binding` に一般化して両方を扱うため、PR #13 の変更が前提。

PR #13 が master にマージされたら、このPRの base は自動で master に追従します。

## Changes Made
- **`src/model/template.rs`**: `BindingSource::MdBottomSheet` variant を追加
- **`src/analyzer/js/component.rs`**:
  - `extract_md_dialog_binding` → `extract_material_show_binding` にリネーム
  - オブジェクト名の判定で `$mdDialog`/`mdDialog` か `$mdBottomSheet`/`mdBottomSheet` かを区別し、対応する `BindingSource` を選択
- **`src/handler/codelens.rs`**: `MdBottomSheet` のラベル `"$mdBottomSheet"` を追加

## Test plan
- [x] 新規テスト 4件すべて通過
  - `test_md_bottom_sheet_template_binding`
  - `test_md_bottom_sheet_controller_reference_registered`
  - `test_md_bottom_sheet_aliased_via_di`
  - `test_md_dialog_and_md_bottom_sheet_distinguished`（同一ファイルでの混在区別）
- [x] 既存テスト全件通過（合計219件、PR #13 のテスト含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)