### PR TITLE
chore: bring PR #14 + #15 ($mdBottomSheet / $mdToast / $mdPanel / ngDialog) into master

### DIFF
--- a/src/analyzer/js/component.rs
+++ b/src/analyzer/js/component.rs
@@ -24,6 +24,9 @@ impl AngularJsAnalyzer {
     /// - `$uibModal.open({...})` - UI Bootstrap モーダルバインディング
     /// - `$mdDialog.show({...})` - Angular Material ダイアログバインディング
     /// - `$mdBottomSheet.show({...})` - Angular Material ボトムシートバインディング
+    /// - `$mdToast.show({...})` - Angular Material トーストバインディング
+    /// - `$mdPanel.open({...})` - Angular Material パネルバインディング
+    /// - `ngDialog.open({...})` - ngDialog (3rd party) バインディング
     pub(super) fn analyze_call_expression(&self, node: Node, source: &str, uri: &Url, ctx: &mut AnalyzerContext) {
         if let Some(callee) = node.child_by_field_name("function") {
             let callee_text = self.node_text(callee, source);
@@ -45,7 +48,7 @@ impl AngularJsAnalyzer {
                         "filter" => self.extract_component_definition(node, source, uri, SymbolKind::Filter, ctx),
                         "constant" => self.extract_component_definition(node, source, uri, SymbolKind::Constant, ctx),
                         "value" => self.extract_component_definition(node, source, uri, SymbolKind::Value, ctx),
-                        "open" => self.extract_modal_binding(node, callee, source, uri),
+                        "open" => self.extract_open_binding(node, callee, source, uri),
                         "show" => self.extract_material_show_binding(node, callee, source, uri),
                         "config" | "run" => self.extract_run_config_di(node, source, ctx),
                         "when" | "otherwise" => self.extract_route_when_di(node, source, uri, ctx),
@@ -57,23 +60,45 @@ impl AngularJsAnalyzer {
         }
     }
 
-    /// $uibModal.open() / $modal.open() からテンプレートバインディングを抽出
-    fn extract_modal_binding(&self, node: Node, callee: Node, source: &str, uri: &Url) {
-        // オブジェクトが$uibModalや$modalかチェック
-        if let Some(object) = callee.child_by_field_name("object") {
+    /// .open({controller, templateUrl}) 系のテンプレートバインディングを抽出
+    ///
+    /// 認識パターン:
+    /// ```javascript
+    /// $uibModal.open({ controller: 'X', templateUrl: '...' });   // UI Bootstrap Modal
+    /// $modal.open({ controller: 'X', templateUrl: '...' });      // 同 (旧名)
+    /// $mdPanel.open({ controller: 'X', templateUrl: '...' });    // Angular Material Panel
+    /// ngDialog.open({ controller: 'X', templateUrl: '...' });    // ngDialog (3rd party)
+    /// ```
+    ///
+    /// オブジェクト名で BindingSource を区別する。それ以外の `.open()` 呼び出し
+    /// (file.open() 等) は自動的にスキップされる。
+    fn extract_open_binding(&self, node: Node, callee: Node, source: &str, uri: &Url) {
+        let binding_source = if let Some(object) = callee.child_by_field_name("object") {
             let obj_text = self.node_text(object, source);
-            if !obj_text.ends_with("Modal") && !obj_text.ends_with("$uibModal") && !obj_text.ends_with("$modal") {
+            // 順序重要: より具体的な接尾辞から先に判定する
+            if obj_text.ends_with("$mdPanel") || obj_text.ends_with("mdPanel") {
+                BindingSource::MdPanel
+            } else if obj_text.ends_with("$ngDialog")
+                || obj_text.ends_with("ngDialog")
+            {
+                BindingSource::NgDialog
+            } else if obj_text.ends_with("$uibModal") || obj_text.ends_with("$modal") {
+                BindingSource::UibModal
+            } else if obj_text.ends_with("Modal") {
+                // 後方互換: ローカル変数名が ...Modal で終わる場合は UibModal 扱い
+                BindingSource::UibModal
+            } else {
                 return;
             }
         } else {
             return;
-        }
+        };
 
         // 引数からオブジェクトを取得
         if let Some(args) = node.child_by_field_name("arguments") {
             if let Some(first_arg) = args.named_child(0) {
                 if first_arg.kind() == "object" {
-                    self.extract_template_binding_from_object(first_arg, source, uri, BindingSource::UibModal);
+                    self.extract_template_binding_from_object(first_arg, source, uri, binding_source);
                 }
             }
         }
@@ -91,13 +116,18 @@ impl AngularJsAnalyzer {
     ///     controller: 'OptionsSheetCtrl',
     ///     templateUrl: 'templates/options-sheet.html'
     /// });
+    /// $mdToast.show({
+    ///     controller: 'CustomToastCtrl',
+    ///     templateUrl: 'templates/custom-toast.html'
+    /// });
     /// ```
     ///
-    /// オブジェクトが `$mdDialog` / `$mdBottomSheet` (および DI で受けた
-    /// `mdDialog` / `mdBottomSheet` エイリアス) の場合のみマッチ。
+    /// オブジェクトが `$mdDialog` / `$mdBottomSheet` / `$mdToast` (および DI
+    /// で受けた `mdDialog` / `mdBottomSheet` / `mdToast` エイリアス) の場合
+    /// のみマッチ。
     ///
-    /// `$mdDialog.confirm()` / `$mdDialog.alert()` のプリセットビルダーは
-    /// オブジェクト引数を取らないため自動的にスキップされる。
+    /// `$mdDialog.confirm()` / `$mdDialog.alert()` / `$mdToast.simple()` の
+    /// プリセットビルダーはオブジェクト引数を取らないため自動的にスキップされる。
     fn extract_material_show_binding(&self, node: Node, callee: Node, source: &str, uri: &Url) {
         let binding_source = if let Some(object) = callee.child_by_field_name("object") {
             let obj_text = self.node_text(object, source);
@@ -105,6 +135,8 @@ impl AngularJsAnalyzer {
                 BindingSource::MdDialog
             } else if obj_text.ends_with("$mdBottomSheet") || obj_text.ends_with("mdBottomSheet") {
                 BindingSource::MdBottomSheet
+            } else if obj_text.ends_with("$mdToast") || obj_text.ends_with("mdToast") {
+                BindingSource::MdToast
             } else {
                 return;
             }

--- a/src/analyzer/js/component.rs
+++ b/src/analyzer/js/component.rs
@@ -23,6 +23,7 @@ impl AngularJsAnalyzer {
     /// - `.value('Name', ...)` - 値定義
     /// - `$uibModal.open({...})` - UI Bootstrap モーダルバインディング
     /// - `$mdDialog.show({...})` - Angular Material ダイアログバインディング
+    /// - `$mdBottomSheet.show({...})` - Angular Material ボトムシートバインディング
     pub(super) fn analyze_call_expression(&self, node: Node, source: &str, uri: &Url, ctx: &mut AnalyzerContext) {
         if let Some(callee) = node.child_by_field_name("function") {
             let callee_text = self.node_text(callee, source);
@@ -45,7 +46,7 @@ impl AngularJsAnalyzer {
                         "constant" => self.extract_component_definition(node, source, uri, SymbolKind::Constant, ctx),
                         "value" => self.extract_component_definition(node, source, uri, SymbolKind::Value, ctx),
                         "open" => self.extract_modal_binding(node, callee, source, uri),
-                        "show" => self.extract_md_dialog_binding(node, callee, source, uri),
+                        "show" => self.extract_material_show_binding(node, callee, source, uri),
                         "config" | "run" => self.extract_run_config_di(node, source, ctx),
                         "when" | "otherwise" => self.extract_route_when_di(node, source, uri, ctx),
                         "state" => self.extract_state_provider_di(node, source, uri, ctx),
@@ -78,7 +79,7 @@ impl AngularJsAnalyzer {
         }
     }
 
-    /// $mdDialog.show({controller, templateUrl}) からテンプレートバインディングを抽出
+    /// Angular Material の .show({controller, templateUrl}) からテンプレートバインディングを抽出
     ///
     /// 認識パターン:
     /// ```javascript
@@ -86,26 +87,36 @@ impl AngularJsAnalyzer {
     ///     controller: 'EditDialogCtrl',
     ///     templateUrl: 'templates/edit-dialog.html'
     /// });
+    /// $mdBottomSheet.show({
+    ///     controller: 'OptionsSheetCtrl',
+    ///     templateUrl: 'templates/options-sheet.html'
+    /// });
     /// ```
     ///
-    /// $mdDialog.confirm() / $mdDialog.alert() などのプリセットビルダーは
+    /// オブジェクトが `$mdDialog` / `$mdBottomSheet` (および DI で受けた
+    /// `mdDialog` / `mdBottomSheet` エイリアス) の場合のみマッチ。
+    ///
+    /// `$mdDialog.confirm()` / `$mdDialog.alert()` のプリセットビルダーは
     /// オブジェクト引数を取らないため自動的にスキップされる。
-    fn extract_md_dialog_binding(&self, node: Node, callee: Node, source: &str, uri: &Url) {
-        // オブジェクトが $mdDialog かチェック
-        if let Some(object) = callee.child_by_field_name("object") {
+    fn extract_material_show_binding(&self, node: Node, callee: Node, source: &str, uri: &Url) {
+        let binding_source = if let Some(object) = callee.child_by_field_name("object") {
             let obj_text = self.node_text(object, source);
-            if !obj_text.ends_with("$mdDialog") && !obj_text.ends_with("mdDialog") {
+            if obj_text.ends_with("$mdDialog") || obj_text.ends_with("mdDialog") {
+                BindingSource::MdDialog
+            } else if obj_text.ends_with("$mdBottomSheet") || obj_text.ends_with("mdBottomSheet") {
+                BindingSource::MdBottomSheet
+            } else {
                 return;
             }
         } else {
             return;
-        }
+        };
 
         // 引数からオブジェクトを取得
         if let Some(args) = node.child_by_field_name("arguments") {
             if let Some(first_arg) = args.named_child(0) {
                 if first_arg.kind() == "object" {
-                    self.extract_template_binding_from_object(first_arg, source, uri, BindingSource::MdDialog);
+                    self.extract_template_binding_from_object(first_arg, source, uri, binding_source);
                 }
             }
         }

--- a/src/handler/codelens.rs
+++ b/src/handler/codelens.rs
@@ -347,6 +347,9 @@ impl CodeLensHandler {
             BindingSource::UibModal => "$uibModal",
             BindingSource::MdDialog => "$mdDialog",
             BindingSource::MdBottomSheet => "$mdBottomSheet",
+            BindingSource::MdToast => "$mdToast",
+            BindingSource::MdPanel => "$mdPanel",
+            BindingSource::NgDialog => "ngDialog",
             BindingSource::NgController => "ng-controller",
         };
 
@@ -444,6 +447,9 @@ impl CodeLensHandler {
             BindingSource::UibModal => "$uibModal",
             BindingSource::MdDialog => "$mdDialog",
             BindingSource::MdBottomSheet => "$mdBottomSheet",
+            BindingSource::MdToast => "$mdToast",
+            BindingSource::MdPanel => "$mdPanel",
+            BindingSource::NgDialog => "ngDialog",
             BindingSource::NgController => "ng-controller",
         };
 

--- a/src/handler/codelens.rs
+++ b/src/handler/codelens.rs
@@ -346,6 +346,7 @@ impl CodeLensHandler {
             BindingSource::StateProvider => "$stateProvider",
             BindingSource::UibModal => "$uibModal",
             BindingSource::MdDialog => "$mdDialog",
+            BindingSource::MdBottomSheet => "$mdBottomSheet",
             BindingSource::NgController => "ng-controller",
         };
 
@@ -442,6 +443,7 @@ impl CodeLensHandler {
             BindingSource::StateProvider => "$stateProvider",
             BindingSource::UibModal => "$uibModal",
             BindingSource::MdDialog => "$mdDialog",
+            BindingSource::MdBottomSheet => "$mdBottomSheet",
             BindingSource::NgController => "ng-controller",
         };
 

--- a/src/model/template.rs
+++ b/src/model/template.rs
@@ -10,6 +10,9 @@ pub enum BindingSource {
     UibModal,
     MdDialog,
     MdBottomSheet,
+    MdToast,
+    MdPanel,
+    NgDialog,
 }
 
 /// HTMLテンプレートとコントローラーのバインディング

--- a/src/model/template.rs
+++ b/src/model/template.rs
@@ -9,6 +9,7 @@ pub enum BindingSource {
     StateProvider,
     UibModal,
     MdDialog,
+    MdBottomSheet,
 }
 
 /// HTMLテンプレートとコントローラーのバインディング

--- a/tests/angularjs_common_syntax_test.rs
+++ b/tests/angularjs_common_syntax_test.rs
@@ -2381,6 +2381,154 @@ angular.module('app', []).controller('MixCtrl', ['$mdDialog', '$mdBottomSheet',
     assert_eq!(b.source, BindingSource::MdBottomSheet);
 }
 
+// ============================================================
+// $mdToast / $mdPanel / ngDialog バインディング
+// ============================================================
+
+#[test]
+fn test_md_toast_show_template_binding() {
+    use angularjs_lsp::model::BindingSource;
+
+    let source = r#"
+angular.module('app', []).controller('PageCtrl', ['$mdToast', function($mdToast) {
+    $mdToast.show({
+        controller: 'CustomToastCtrl',
+        templateUrl: 'templates/custom-toast.html'
+    });
+}]);
+"#;
+    let index = analyze_js(source);
+    let bindings = index.templates.get_all_template_bindings();
+    let binding = bindings
+        .iter()
+        .find(|b| b.template_path.contains("custom-toast.html"))
+        .expect("$mdToast.show のテンプレートバインディングが登録されるべき");
+
+    assert_eq!(binding.controller_name, "CustomToastCtrl");
+    assert_eq!(binding.source, BindingSource::MdToast);
+    assert!(
+        has_reference(&index, "CustomToastCtrl"),
+        "controller 文字列参照も登録されるべき"
+    );
+}
+
+#[test]
+fn test_md_panel_open_template_binding() {
+    use angularjs_lsp::model::BindingSource;
+
+    let source = r#"
+angular.module('app', []).controller('PageCtrl', ['$mdPanel', function($mdPanel) {
+    $mdPanel.open({
+        controller: 'PanelCtrl',
+        templateUrl: 'templates/panel.html'
+    });
+}]);
+"#;
+    let index = analyze_js(source);
+    let bindings = index.templates.get_all_template_bindings();
+    let binding = bindings
+        .iter()
+        .find(|b| b.template_path.contains("panel.html"))
+        .expect("$mdPanel.open のテンプレートバインディングが登録されるべき");
+
+    assert_eq!(binding.controller_name, "PanelCtrl");
+    assert_eq!(binding.source, BindingSource::MdPanel);
+    assert!(
+        has_reference(&index, "PanelCtrl"),
+        "controller 文字列参照も登録されるべき"
+    );
+}
+
+#[test]
+fn test_ng_dialog_open_template_binding() {
+    use angularjs_lsp::model::BindingSource;
+
+    let source = r#"
+angular.module('app', []).controller('PageCtrl', ['ngDialog', function(ngDialog) {
+    ngDialog.open({
+        controller: 'NgDialogCtrl',
+        templateUrl: 'templates/ng-dialog.html'
+    });
+}]);
+"#;
+    let index = analyze_js(source);
+    let bindings = index.templates.get_all_template_bindings();
+    let binding = bindings
+        .iter()
+        .find(|b| b.template_path.contains("ng-dialog.html"))
+        .expect("ngDialog.open のテンプレートバインディングが登録されるべき");
+
+    assert_eq!(binding.controller_name, "NgDialogCtrl");
+    assert_eq!(binding.source, BindingSource::NgDialog);
+    assert!(
+        has_reference(&index, "NgDialogCtrl"),
+        "controller 文字列参照も登録されるべき"
+    );
+}
+
+#[test]
+fn test_uib_modal_still_recognized_after_open_refactor() {
+    // .open() 経路のリファクタで $uibModal が壊れていないことを確認（回帰防止）
+    use angularjs_lsp::model::BindingSource;
+
+    let source = r#"
+angular.module('app', []).controller('PageCtrl', ['$uibModal', function($uibModal) {
+    $uibModal.open({
+        controller: 'StillUibCtrl',
+        templateUrl: 'templates/still-uib.html'
+    });
+}]);
+"#;
+    let index = analyze_js(source);
+    let bindings = index.templates.get_all_template_bindings();
+    let binding = bindings
+        .iter()
+        .find(|b| b.template_path.contains("still-uib.html"))
+        .expect("$uibModal は引き続き UibModal として認識されるべき");
+
+    assert_eq!(binding.source, BindingSource::UibModal);
+}
+
+#[test]
+fn test_md_panel_and_ng_dialog_distinguished_from_uib_modal() {
+    // 同じ .open() でもオブジェクト名で BindingSource が分かれること
+    use angularjs_lsp::model::BindingSource;
+
+    let source = r#"
+angular.module('app', []).controller('MixCtrl', ['$uibModal', '$mdPanel', 'ngDialog',
+    function($uibModal, $mdPanel, ngDialog) {
+        $uibModal.open({ controller: 'A', templateUrl: 'a.html' });
+        $mdPanel.open({ controller: 'B', templateUrl: 'b.html' });
+        ngDialog.open({ controller: 'C', templateUrl: 'c.html' });
+    }]);
+"#;
+    let index = analyze_js(source);
+    let bindings = index.templates.get_all_template_bindings();
+    let a = bindings.iter().find(|b| b.template_path.ends_with("a.html")).unwrap();
+    let b = bindings.iter().find(|b| b.template_path.ends_with("b.html")).unwrap();
+    let c = bindings.iter().find(|b| b.template_path.ends_with("c.html")).unwrap();
+    assert_eq!(a.source, BindingSource::UibModal);
+    assert_eq!(b.source, BindingSource::MdPanel);
+    assert_eq!(c.source, BindingSource::NgDialog);
+}
+
+#[test]
+fn test_other_open_calls_still_ignored() {
+    // file.open() のような無関係な .open() は無視されること
+    let source = r#"
+angular.module('app', []).controller('PageCtrl', ['fileSystem', function(fs) {
+    fs.open({ controller: 'NotAModalCtrl', templateUrl: 'fake.html' });
+}]);
+"#;
+    let index = analyze_js(source);
+    let bindings = index.templates.get_all_template_bindings();
+    assert!(
+        bindings.is_empty(),
+        "無関係な .open() は無視されるべき (got: {:?})",
+        bindings.iter().map(|b| &b.template_path).collect::<Vec<_>>()
+    );
+}
+
 #[test]
 fn test_md_dialog_aliased_via_di() {
     // DI で受けた $mdDialog の別名（mdDialog 等）も認識する

--- a/tests/angularjs_common_syntax_test.rs
+++ b/tests/angularjs_common_syntax_test.rs
@@ -2287,6 +2287,101 @@ angular.module('app', []).controller('PageCtrl', ['$scope', function($scope) {
 }
 
 #[test]
+fn test_md_bottom_sheet_template_binding() {
+    use angularjs_lsp::model::BindingSource;
+
+    let source = r#"
+angular.module('app', []).controller('PageCtrl', ['$mdBottomSheet', function($mdBottomSheet) {
+    $mdBottomSheet.show({
+        controller: 'OptionsSheetCtrl',
+        templateUrl: 'templates/options-sheet.html'
+    });
+}]);
+"#;
+    let index = analyze_js(source);
+    let bindings = index.templates.get_all_template_bindings();
+    let binding = bindings
+        .iter()
+        .find(|b| b.template_path.contains("options-sheet.html"))
+        .expect("$mdBottomSheet.show のテンプレートバインディングが登録されるべき");
+
+    assert_eq!(binding.controller_name, "OptionsSheetCtrl");
+    assert_eq!(
+        binding.source,
+        BindingSource::MdBottomSheet,
+        "BindingSource は MdBottomSheet であるべき"
+    );
+}
+
+#[test]
+fn test_md_bottom_sheet_controller_reference_registered() {
+    let source = r#"
+angular.module('app', []).controller('PageCtrl', ['$mdBottomSheet', function($mdBottomSheet) {
+    $mdBottomSheet.show({
+        controller: 'ShareSheetCtrl',
+        templateUrl: 'templates/share-sheet.html'
+    });
+}]);
+"#;
+    let index = analyze_js(source);
+    assert!(
+        has_reference(&index, "ShareSheetCtrl"),
+        "$mdBottomSheet.show の controller 参照が登録されるべき"
+    );
+}
+
+#[test]
+fn test_md_bottom_sheet_aliased_via_di() {
+    use angularjs_lsp::model::BindingSource;
+
+    let source = r#"
+angular.module('app', []).controller('PageCtrl', function() {
+    var mdBottomSheet = angular.injector(['ng', 'material.components.bottomSheet']).get('$mdBottomSheet');
+    mdBottomSheet.show({
+        controller: 'AliasedSheetCtrl',
+        templateUrl: 'templates/aliased-sheet.html'
+    });
+});
+"#;
+    let index = analyze_js(source);
+    let bindings = index.templates.get_all_template_bindings();
+    let binding = bindings
+        .iter()
+        .find(|b| b.template_path.contains("aliased-sheet.html"))
+        .expect("mdBottomSheet (エイリアス) からも binding を抽出すべき");
+    assert_eq!(binding.controller_name, "AliasedSheetCtrl");
+    assert_eq!(binding.source, BindingSource::MdBottomSheet);
+}
+
+#[test]
+fn test_md_dialog_and_md_bottom_sheet_distinguished() {
+    // 同一ファイル内に両方が存在しても BindingSource で区別されること
+    use angularjs_lsp::model::BindingSource;
+
+    let source = r#"
+angular.module('app', []).controller('MixCtrl', ['$mdDialog', '$mdBottomSheet',
+    function($mdDialog, $mdBottomSheet) {
+        $mdDialog.show({ controller: 'DialogA', templateUrl: 'a.html' });
+        $mdBottomSheet.show({ controller: 'SheetB', templateUrl: 'b.html' });
+    }]);
+"#;
+    let index = analyze_js(source);
+    let bindings = index.templates.get_all_template_bindings();
+
+    let a = bindings
+        .iter()
+        .find(|b| b.template_path.ends_with("a.html"))
+        .expect("a.html のバインディングがあるべき");
+    let b = bindings
+        .iter()
+        .find(|b| b.template_path.ends_with("b.html"))
+        .expect("b.html のバインディングがあるべき");
+
+    assert_eq!(a.source, BindingSource::MdDialog);
+    assert_eq!(b.source, BindingSource::MdBottomSheet);
+}
+
+#[test]
 fn test_md_dialog_aliased_via_di() {
     // DI で受けた $mdDialog の別名（mdDialog 等）も認識する
     use angularjs_lsp::model::BindingSource;


### PR DESCRIPTION
## Summary
PR #14 (`$mdBottomSheet`) と PR #15 (`$mdToast` / `$mdPanel` / `ngDialog`) は **MERGED** とマークされていますが、実際には master まで到達していませんでした。それぞれの base が前段の PR ブランチを向いていたため、PR #13 マージ後に取り残された形です。

このPRはその孤立した2コミットを master に取り込みます。

## 経緯
- PR #13 のマージ → master へ正常着地
- PR #14 のマージ → base が `feat/md-dialog-binding`（既マージ済み）だったため、そちらに着地して master には入らず
- PR #15 のマージ → 同じく `feat/md-bottom-sheet-binding` に着地

`feat/md-bottom-sheet-binding` ブランチには PR #14 + #15 の両方のコミットが揃っているので、これを master に持ち込みます。

## Diff
PR #14 + PR #15 の合計です（PR #13 マージ後の `feat/md-bottom-sheet-binding` の差分）。

```
src/analyzer/js/component.rs          |  79 ++++++++---
src/handler/codelens.rs               |   8 ++
src/model/template.rs                 |   4 +
tests/angularjs_common_syntax_test.rs | 243 ++++++++++++++++++++++++++++++++++
```

## マージ後の手順
このPRがマージされたら、PR #16 を master ベースで rebase 必要（前回の PR #11 と同じ流れ）。私がやります。

## 再発防止
今後は **PR を切る時点から最初から base = master** にすることで、このタイプの事故は完全に防げます（依存PRがあればコメントで明示し、コンフリクトしたら都度 rebase）。スタックで切るのは便利だが、merge tooling との相性が悪いので避けるべき。