### PR TITLE
perf: HTML更新時、埋め込み script が無ければ全JS診断の再発行をスキップ

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -170,14 +170,29 @@ impl Backend {
                 let bl_documents = Arc::clone(&documents);
 
                 // Run CPU-intensive analysis on the blocking thread pool
-                let analysis_done = tokio::task::spawn_blocking(move || {
+                //
+                // 戻り値: Some((had_embedded_scripts_before, has_embedded_scripts_after))
+                //   - 解析が走らなかった場合は None
+                //   - 両方 false なら HTML 更新が JS 側のシンボル空間に影響しないので
+                //     「全 JS 診断の再発行」をスキップできる
+                //   - どちらかが true なら、JS ファイル側の参照解決結果が変わり得るので
+                //     依存ファイルの診断を更新する必要がある
+                let analysis_result = tokio::task::spawn_blocking(move || {
                     let latest_text = match bl_documents.get(&bl_uri) {
                         Some(doc) => doc.value().clone(),
-                        None => return false,
+                        None => return None,
                     };
+
+                    // 解析前: この HTML に紐付く JS 由来シンボルがあるか
+                    // (前回 embedded script 由来で登録されたものが clear_document で消える)
+                    let had_embedded_before = !bl_index
+                        .definitions
+                        .get_definitions_for_uri(&bl_uri)
+                        .is_empty();
 
                     let scripts = bl_html_analyzer
                         .analyze_document_and_extract_scripts(&bl_uri, &latest_text);
+                    let has_embedded_after = !scripts.is_empty();
                     bl_index.templates.mark_html_analyzed(&bl_uri);
                     for script in scripts {
                         bl_analyzer.analyze_embedded_script(
@@ -202,20 +217,28 @@ impl Backend {
                             bl_html_analyzer.analyze_document(&child_uri, doc.value());
                         }
                     }
-                    true
+                    Some((had_embedded_before, has_embedded_after))
                 })
                 .await
-                .unwrap_or(false);
+                .ok()
+                .flatten();
 
-                if analysis_done {
+                if let Some((had_embedded_before, has_embedded_after)) = analysis_result {
                     publish_html_diagnostics(&client, &index, &diagnostics_config, &uri).await;
-                    republish_all_js_diagnostics(
-                        &client,
-                        &index,
-                        &diagnostics_config,
-                        &documents,
-                    )
-                    .await;
+
+                    // JS シンボルに変化があり得る場合のみ、開いている JS ファイルの
+                    // 診断を再発行する。embedded script が前後どちらも無ければ
+                    // この HTML 更新は JS 側のシンボル解決に影響しないのでスキップ。
+                    if had_embedded_before || has_embedded_after {
+                        republish_all_js_diagnostics(
+                            &client,
+                            &index,
+                            &diagnostics_config,
+                            &documents,
+                        )
+                        .await;
+                    }
+
                     let _ = client.semantic_tokens_refresh().await;
                     let _ = client.code_lens_refresh().await;
                 }


### PR DESCRIPTION
## Summary
HTML が変わると常に「開いている全 JS ファイルの diagnostics を再発行する」処理が走っていました（`server/mod.rs:212-218`）。HTML 内 `<script>` タグで定義されたシンボルが他の JS ファイルから参照されているケースのための保険ですが、現代的な AngularJS プロジェクトでは embedded script を持たない HTML が大半で、HTML を1文字変更するたびに数十〜数百ファイルの診断を全件再計算するのは無駄に重い状態でした。

## 修正方針
`spawn_blocking` の戻り値を `(had_embedded_before, has_embedded_after)` に拡張し、両方 `false` のときだけ全JS再発行をスキップします。

| before | after | 動作 |
|---|---|---|
| なし | なし | **スキップ** ← この PR で削減される大半のケース |
| なし | あり | 再発行（新規 script のシンボルを他 JS が参照しうる） |
| あり | あり | 再発行（変更が他 JS に波及しうる） |
| あり | なし | 再発行（script 削除で他 JS 参照が未定義になりうる） |

- `had_embedded_before`: 解析前に index がこの HTML URI 由来の定義を持っているか
- `has_embedded_after`: `analyze_document_and_extract_scripts` が返したスクリプトが空でないか

両方を見ることで「scriptが今回削除された」ケースもカバーします。

## Changes
- **`src/server/mod.rs`** の HTML 更新フロー1箇所のみ
- `publish_html_diagnostics`、`semantic_tokens_refresh`、`code_lens_refresh` は従来通り常時実行
- ts_proxy への中継も従来通り

## Test plan
- [x] 既存テスト全件通過（合計230件）
- [ ] 実プロジェクトで HTML を編集中、CPU使用率が大幅に下がることを目視確認

## 副次効果
最近の修正リスト (#1-4) の **#1**「HTML更新で全JS再発行」を解消。残り (#2 JS→HTML 波及なし、#3 ts_proxy 常時通知、#4 pending_reanalysis 片方向) は別 PR で順次対応予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)