### PR TITLE
perf: ts_proxy への HTML/非JS 通知を抑制

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -366,8 +366,12 @@ impl Backend {
             });
         }
 
-        if let Some(ref proxy) = *self.ts_proxy.read().await {
-            proxy.did_change(&uri, &text, version).await;
+        // tsserver は HTML を解釈できないので JS ファイルのみ通知する
+        // (HTML を languageId=javascript で渡すと tsserver が無駄に parse する)
+        if is_js_file(&uri) {
+            if let Some(ref proxy) = *self.ts_proxy.read().await {
+                proxy.did_change(&uri, &text, version).await;
+            }
         }
     }
 
@@ -423,9 +427,12 @@ impl Backend {
             self.publish_diagnostics_for_js(&uri).await;
         }
 
-        if let Some(ref proxy) = *self.ts_proxy.read().await {
-            proxy.did_open(&uri, &text).await;
-            self.ts_opened_files.insert(uri.clone(), true);
+        // tsserver は JS ファイルだけ知っていれば良い (HTML は内部ハンドラで処理)
+        if is_js_file(&uri) {
+            if let Some(ref proxy) = *self.ts_proxy.read().await {
+                proxy.did_open(&uri, &text).await;
+                self.ts_opened_files.insert(uri.clone(), true);
+            }
         }
     }
 
@@ -1327,8 +1334,13 @@ impl LanguageServer for Backend {
     }
 
     async fn did_close(&self, params: DidCloseTextDocumentParams) {
-        if let Some(ref proxy) = *self.ts_proxy.read().await {
-            proxy.did_close(&params.text_document.uri).await;
+        let uri = &params.text_document.uri;
+        // 実際に tsserver に開いたファイルだけを close する
+        // (HTML 等、tsserver に渡していないファイルに did_close を送る必要はない)
+        if self.ts_opened_files.remove(uri).is_some() {
+            if let Some(ref proxy) = *self.ts_proxy.read().await {
+                proxy.did_close(uri).await;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
`on_open` / `on_change` / `did_close` で **全ファイル種別**を `ts_proxy`（tsserver）に通知していたため、tsserver が解釈できない HTML ファイルでも以下の無駄が発生していました：

- HTML が `languageId: "javascript"` として開かれ、tsserver が HTML を無理やり JS として parse
- HTML 編集ごとに `did_change` が IPC で飛ぶ（tsserver は何もできずに捨てる）
- tsserver のメモリに HTML 内容が保持される

## Changes Made
3箇所をガード：

1. **`on_change`** (line 369): `is_js_file(&uri)` ガード追加
2. **`on_open`** (line 426): `is_js_file(&uri)` ガード追加（tsserver には `.js` だけ知らせる）
3. **`did_close`** (line 1336): `ts_opened_files` で「実際に開いたファイル」のみ `did_close` を送る
   - 同時に `ts_opened_files.remove(uri)` で再オープン可能に
   - **副次的バグ修正**: 従来は close 後も `ts_opened_files` に残っていて、`ensure_ts_file_opened` の lazy open が再オープン時に動かなかった

`ts_proxy` への lazy open（`ensure_ts_file_opened`）は JS handler からの fallback 経路のみで使われ、HTML を渡す経路は元々無いため、機能への影響はなし。

## Test plan
- [x] 既存テスト全件通過（合計235件）
- [ ] HTML 編集中の tsserver プロセスの CPU/メモリ使用率が下がることを目視確認
- [ ] JS ファイル編集時の tsserver 経由の補完・hover が引き続き動作することを目視確認

## 残課題（#1-#4 リスト）
- ✅ #1 HTML更新で全JS再発行 → PR #19
- ✅ #2 JS→HTML 波及なし → PR #20
- ✅ #3 ts_proxy 常時通知 → 本 PR
- 🔜 #4 pending_reanalysis 片方向のみ → 次の PR 候補

🤖 Generated with [Claude Code](https://claude.com/claude-code)