### PR TITLE
feat: 子HTML変更時に親HTMLの診断を再発行 (ng-include 子→親 波及)

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -215,12 +215,12 @@ impl Backend {
 
                 // Run CPU-intensive analysis on the blocking thread pool
                 //
-                // 戻り値: Some((had_embedded_scripts_before, has_embedded_scripts_after))
+                // 戻り値: Some((had_embedded_scripts_before, has_embedded_scripts_after, affected_parents))
                 //   - 解析が走らなかった場合は None
-                //   - 両方 false なら HTML 更新が JS 側のシンボル空間に影響しないので
-                //     「全 JS 診断の再発行」をスキップできる
-                //   - どちらかが true なら、JS ファイル側の参照解決結果が変わり得るので
-                //     依存ファイルの診断を更新する必要がある
+                //   - 埋め込みscript の前後フラグは「全JS診断再発行をスキップできるか」
+                //     の判定に使う (PR #19)
+                //   - affected_parents は、この HTML を ng-include で参照している親
+                //     HTML のうち、再解析した URI の一覧 (子→親の波及対応)
                 let analysis_result = tokio::task::spawn_blocking(move || {
                     let latest_text = match bl_documents.get(&bl_uri) {
                         Some(doc) => doc.value().clone(),
@@ -261,13 +261,38 @@ impl Backend {
                             bl_html_analyzer.analyze_document(&child_uri, doc.value());
                         }
                     }
-                    Some((had_embedded_before, has_embedded_after))
+
+                    // 子→親の波及: この HTML を ng-include で取り込んでいる親 URI
+                    // のうち、エディタで開いているものを集める。
+                    //
+                    // 親の HTML 自身は再解析しない (parent の HTML 構造や ng-include
+                    // 定義は親自身の analyze で更新される情報で、子の変更では変わらない)。
+                    // 影響を受けるのは「親の診断 (例: <div ng-controller="ChildCtrl">
+                    // で参照する ChildCtrl が child の <script> 変更で消えた等)」のみ
+                    // で、診断は index の現状を都度参照するので、再発行するだけで済む。
+                    let mut affected_parents: Vec<Url> = Vec::new();
+                    let mut seen: HashSet<Url> = HashSet::new();
+                    seen.insert(bl_uri.clone());
+                    for (parent_uri, _) in
+                        bl_index.templates.get_parent_templates_for_child(&bl_uri)
+                    {
+                        if !seen.insert(parent_uri.clone()) {
+                            continue;
+                        }
+                        if bl_documents.contains_key(&parent_uri) {
+                            affected_parents.push(parent_uri);
+                        }
+                    }
+
+                    Some((had_embedded_before, has_embedded_after, affected_parents))
                 })
                 .await
                 .ok()
                 .flatten();
 
-                if let Some((had_embedded_before, has_embedded_after)) = analysis_result {
+                if let Some((had_embedded_before, has_embedded_after, affected_parents)) =
+                    analysis_result
+                {
                     publish_html_diagnostics(&client, &index, &diagnostics_config, &uri).await;
 
                     // JS シンボルに変化があり得る場合のみ、開いている JS ファイルの
@@ -279,6 +304,17 @@ impl Backend {
                             &index,
                             &diagnostics_config,
                             &documents,
+                        )
+                        .await;
+                    }
+
+                    // 子→親の波及で再解析した親 HTML の診断も更新する
+                    for parent_uri in affected_parents {
+                        publish_html_diagnostics(
+                            &client,
+                            &index,
+                            &diagnostics_config,
+                            &parent_uri,
                         )
                         .await;
                     }

--- a/tests/angularjs_common_syntax_test.rs
+++ b/tests/angularjs_common_syntax_test.rs
@@ -2728,3 +2728,89 @@ angular.module('app', []).controller('PageCtrl', function() {
     assert_eq!(binding.controller_name, "AliasedDialogCtrl");
     assert_eq!(binding.source, BindingSource::MdDialog);
 }
+
+// ============================================================
+// 子HTML変更時の親HTML再解析 (ng-include 子→親 波及)
+// ============================================================
+
+#[test]
+fn test_get_parent_templates_for_child_finds_ng_include_parent() {
+    // parent.html が <div ng-include="'child.html'"> を含む場合、
+    // child.html から get_parent_templates_for_child で parent.html が引ける
+    let index = Arc::new(Index::new());
+    let js_analyzer = Arc::new(AngularJsAnalyzer::new(index.clone()));
+    let html_analyzer = HtmlAngularJsAnalyzer::new(index.clone(), js_analyzer);
+
+    let parent_uri = Url::parse("file:///app/parent.html").unwrap();
+    let parent_html = r#"
+<div ng-controller="ParentCtrl">
+    <div ng-include="'child.html'"></div>
+</div>
+"#;
+    html_analyzer.analyze_document(&parent_uri, parent_html);
+
+    let child_uri = Url::parse("file:///app/child.html").unwrap();
+    let parents = index.templates.get_parent_templates_for_child(&child_uri);
+
+    assert!(
+        parents.iter().any(|(uri, _)| uri == &parent_uri),
+        "child.html の parent として parent.html が引けるべき (got: {:?})",
+        parents.iter().map(|(u, _)| u.as_str()).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_get_parent_templates_for_child_returns_empty_for_unincluded() {
+    // ng-include されていないファイルは parent を持たない
+    let index = Arc::new(Index::new());
+    let js_analyzer = Arc::new(AngularJsAnalyzer::new(index.clone()));
+    let html_analyzer = HtmlAngularJsAnalyzer::new(index.clone(), js_analyzer);
+
+    let parent_uri = Url::parse("file:///app/parent.html").unwrap();
+    let parent_html = r#"
+<div ng-controller="ParentCtrl">
+    <div ng-include="'used.html'"></div>
+</div>
+"#;
+    html_analyzer.analyze_document(&parent_uri, parent_html);
+
+    let unrelated_uri = Url::parse("file:///app/unrelated.html").unwrap();
+    let parents = index.templates.get_parent_templates_for_child(&unrelated_uri);
+    assert!(
+        parents.is_empty(),
+        "ng-include されていないファイルは parent を持たないべき"
+    );
+}
+
+#[test]
+fn test_child_re_analysis_keeps_parent_in_dependency_graph() {
+    // 子 HTML を再解析しても、親 HTML との ng-include 依存関係は維持される。
+    // (親の analyze で登録された binding を、子側の clear/再解析が壊さないこと。
+    //  これが壊れていたら on_change 後の get_parent_templates_for_child が空を
+    //  返し、親への診断再発行が走らなくなる)
+    let index = Arc::new(Index::new());
+    let js_analyzer = Arc::new(AngularJsAnalyzer::new(index.clone()));
+    let html_analyzer = HtmlAngularJsAnalyzer::new(index.clone(), js_analyzer);
+
+    let parent_uri = Url::parse("file:///app/parent.html").unwrap();
+    let child_uri = Url::parse("file:///app/child.html").unwrap();
+
+    let parent_html = r#"
+<div ng-controller="ParentCtrl">
+    <div ng-include="'child.html'"></div>
+</div>
+"#;
+    html_analyzer.analyze_document(&parent_uri, parent_html);
+    html_analyzer.analyze_document(&child_uri, r#"<div>v1</div>"#);
+
+    // 子を編集して再解析
+    html_analyzer.analyze_document(&child_uri, r#"<div ng-controller="ChildCtrl">v2</div>"#);
+
+    // 子→親の依存関係が壊れていないこと (server 側の波及処理が動く前提)
+    let parents = index.templates.get_parent_templates_for_child(&child_uri);
+    assert!(
+        parents.iter().any(|(uri, _)| uri == &parent_uri),
+        "子の再解析後も parent.html が parent として引けるべき (got: {:?})",
+        parents.iter().map(|(u, _)| u.as_str()).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Summary
これまで `pending_reanalysis` は親→子方向のみで、子 HTML が変更されても `ng-include` で取り込んでいる親 HTML の診断は更新されませんでした。例えば child の `<script>` で定義していた `ChildCtrl` を消した場合、parent の `<div ng-controller="ChildCtrl">` は古い診断のまま（"ChildCtrl is undefined" が出るべきなのに出ない）。

この PR で、子 HTML 変更時に「この HTML を ng-include している開いている親 HTML」の診断をピンポイント再発行します。

## 設計判断
- **親の HTML 自体は再解析しない**。親の HTML 構造や ng-include 定義は親自身の analyze で更新される情報で、子の変更では変わらないため。
- 影響を受けるのは **親の診断（グローバルなシンボル空間に依存する controller/scope 参照）** のみ。診断は index の現状を都度参照するので、再発行するだけで反映される。
- **1段のみ波及**。多段 ng-include の連鎖は次の更新サイクルで吸収される。
- **開いている親のみ対象**（`documents.contains_key`）。

## Changes Made
- **`src/server/mod.rs`**:
  - `spawn_blocking` の戻り値を `Option<(had_embedded_before, has_embedded_after, affected_parents)>` の3要素タプルに拡張
  - 子→親の依存集合を `get_parent_templates_for_child` で取得
  - メインスレッドで `affected_parents` の各親 URI について `publish_html_diagnostics` を呼ぶ

## Test plan
- [x] 統合テスト 3件追加
  - `get_parent_templates_for_child` が ng-include 親を返すこと
  - 未 include なファイルは empty を返すこと
  - 子再解析後も親との依存関係が壊れないこと（波及処理の前提）
- [x] 既存テスト全件通過（合計238件）

## #1-#4 リスト完了
- ✅ #1 HTML更新で全JS再発行 → PR #19
- ✅ #2 JS→HTML 波及なし → PR #20
- ✅ #3 ts_proxy 常時通知 → PR #21
- ✅ #4 pending_reanalysis 片方向 → 本 PR

## 残課題（今後の検討対象、必須ではない）
- `pending_reanalysis` 多段への対応（grandchild→child→parent の連鎖）
  - 現状は1段ずつ次回サイクルで吸収する形で実用上は問題なし
- 親の embedded scripts が child 経由の影響を受ける場合の追加処理
  - 子の embedded script 変更が親の embedded script の解釈に影響するレアケース。実用例少なめ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)