### PR TITLE
feat: custom directive と component bindings の属性値を Angular 式として解析

### DIFF
--- a/src/analyzer/html/directives.rs
+++ b/src/analyzer/html/directives.rs
@@ -2,6 +2,10 @@
 
 use phf::phf_set;
 
+use crate::index::Index;
+use crate::model::SymbolKind;
+use crate::util::kebab_to_camel;
+
 /// AngularJS directive set (O(1) lookup)
 static NG_DIRECTIVE_SET: phf::Set<&'static str> = phf_set! {
     // Data binding
@@ -88,4 +92,59 @@ static NG_DIRECTIVE_SET: phf::Set<&'static str> = phf_set! {
 /// Check if attribute name is a supported AngularJS directive
 pub fn is_ng_directive(attr_name: &str) -> bool {
     NG_DIRECTIVE_SET.contains(attr_name)
+}
+
+/// 属性値を Angular 式として解析すべきか判定する。
+///
+/// 以下のいずれかに当てはまる場合 `true` を返す:
+/// 1. ビルトイン or 既知ライブラリの ng-* / uib-* / ngf-* ディレクティブ
+///    (`is_ng_directive` の判定。`data-` 接頭辞は揺らぎを吸収)
+/// 2. JS 側で `.directive('name', ...)` 登録された custom directive
+///    (kebab-case → camelCase で `SymbolKind::Directive` を index に検索)
+/// 3. `element_name` が `.component('name', ...)` 登録された component で、
+///    かつ属性名がその component の `bindings` の名前と一致
+///    (`SymbolKind::ComponentBinding` で `componentName.bindingName` を検索)
+///
+/// `element_name` は属性が属する要素のタグ名 (kebab-case)。
+/// `None` の場合は判定 (1) と (2) のみ行う (component bindings は判定不能)。
+pub fn is_directive_attribute(
+    attr_name: &str,
+    element_name: Option<&str>,
+    index: &Index,
+) -> bool {
+    // 1. ビルトイン/既知ライブラリ
+    if is_ng_directive(attr_name) {
+        return true;
+    }
+
+    // data- 接頭辞を剥がしてから index 検索
+    let stripped = attr_name.strip_prefix("data-").unwrap_or(attr_name);
+    let camel = kebab_to_camel(stripped);
+
+    // 2. custom directive
+    if index
+        .definitions
+        .has_definition_of_kind(&camel, SymbolKind::Directive)
+    {
+        return true;
+    }
+
+    // 3. component binding (要素名が必要)
+    if let Some(elem) = element_name {
+        let elem_camel = kebab_to_camel(elem);
+        if index
+            .definitions
+            .has_definition_of_kind(&elem_camel, SymbolKind::Component)
+        {
+            let binding_name = format!("{}.{}", elem_camel, camel);
+            if index
+                .definitions
+                .has_definition_of_kind(&binding_name, SymbolKind::ComponentBinding)
+            {
+                return true;
+            }
+        }
+    }
+
+    false
 }

--- a/src/analyzer/html/expression.rs
+++ b/src/analyzer/html/expression.rs
@@ -1,6 +1,6 @@
 //! Angular式のパースとコンテキスト判定
 
-use super::directives::is_ng_directive;
+use super::directives::is_directive_attribute;
 use super::HtmlAngularJsAnalyzer;
 
 use tree_sitter::{Parser, Tree};
@@ -222,9 +222,11 @@ impl HtmlAngularJsAnalyzer {
             let after_eq = &before_cursor[eq_idx + 2..];
             // 属性値の閉じクォートがない場合、属性値内にいる
             if !after_eq.contains('"') {
-                // 属性名を抽出（`="` の前の部分）
-                if let Some(attr_name) = Self::extract_attr_name(&before_cursor[..eq_idx]) {
-                    if is_ng_directive(attr_name) {
+                // 属性名と要素名を抽出（`="` の前の部分から）
+                let before_eq = &before_cursor[..eq_idx];
+                if let Some(attr_name) = Self::extract_attr_name(before_eq) {
+                    let elem = Self::extract_element_name_before(before_eq);
+                    if is_directive_attribute(attr_name, elem, &self.index) {
                         return true;
                     }
                 }
@@ -236,9 +238,11 @@ impl HtmlAngularJsAnalyzer {
             let after_eq = &before_cursor[eq_idx + 2..];
             // 属性値の閉じクォートがない場合、属性値内にいる
             if !after_eq.contains('\'') {
-                // 属性名を抽出（`='` の前の部分）
-                if let Some(attr_name) = Self::extract_attr_name(&before_cursor[..eq_idx]) {
-                    if is_ng_directive(attr_name) {
+                // 属性名と要素名を抽出（`='` の前の部分から）
+                let before_eq = &before_cursor[..eq_idx];
+                if let Some(attr_name) = Self::extract_attr_name(before_eq) {
+                    let elem = Self::extract_element_name_before(before_eq);
+                    if is_directive_attribute(attr_name, elem, &self.index) {
                         return true;
                     }
                 }
@@ -246,6 +250,25 @@ impl HtmlAngularJsAnalyzer {
         }
 
         false
+    }
+
+    /// 文字列の末尾位置から見て、現在開いている `<tag` の `tag` 名を抽出する
+    /// (component bindings 判定に使う element_tag_name)
+    fn extract_element_name_before(s: &str) -> Option<&str> {
+        let lt_idx = s.rfind('<')?;
+        let after_lt = &s[lt_idx + 1..];
+        // 閉じタグ (`</`) は除外
+        if after_lt.starts_with('/') {
+            return None;
+        }
+        let end = after_lt
+            .find(|c: char| c.is_whitespace() || c == '>' || c == '/')
+            .unwrap_or(after_lt.len());
+        if end == 0 {
+            None
+        } else {
+            Some(&after_lt[..end])
+        }
     }
 
     /// 文字列の末尾から属性名を抽出

--- a/src/analyzer/html/local_variable.rs
+++ b/src/analyzer/html/local_variable.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use tower_lsp::lsp_types::Url;
 use tree_sitter::Node;
 
-use super::directives::is_ng_directive;
+use super::directives::is_directive_attribute;
 use super::variable_parser::{parse_ng_init_expression, parse_ng_repeat_expression};
 use super::HtmlAngularJsAnalyzer;
 use crate::model::{HtmlLocalVariable, HtmlLocalVariableReference, HtmlLocalVariableSource};
@@ -302,6 +302,11 @@ impl HtmlAngularJsAnalyzer {
         uri: &Url,
         active_scopes: &HashMap<String, (u32, u32)>,
     ) {
+        // 要素のタグ名を取得 (component bindings 判定で必要)
+        let element_tag_name = self
+            .find_child_by_kind(start_tag, "tag_name")
+            .map(|n| self.node_text(n, source));
+
         let mut cursor = start_tag.walk();
         for child in start_tag.children(&mut cursor) {
             if child.kind() == "attribute" {
@@ -374,8 +379,13 @@ impl HtmlAngularJsAnalyzer {
                         let value_byte_col = value_node.start_position().column + 1;
                         let value_start_col = self.byte_col_to_utf16_col(source, value_start_line, value_byte_col);
 
-                        if is_ng_directive(&attr_name) {
-                            // ngディレクティブ: 属性値全体をAngular式として解析
+                        if is_directive_attribute(
+                            &attr_name,
+                            element_tag_name.as_deref(),
+                            &self.index,
+                        ) {
+                            // ngディレクティブ または custom directive / component binding:
+                            // 属性値全体をAngular式として解析
                             // フィルタを除去
                             let expr = value.split('|').next().unwrap_or(value);
 

--- a/src/analyzer/html/scope_reference.rs
+++ b/src/analyzer/html/scope_reference.rs
@@ -3,7 +3,7 @@
 use tower_lsp::lsp_types::Url;
 use tree_sitter::Node;
 
-use super::directives::is_ng_directive;
+use super::directives::is_directive_attribute;
 use crate::model::HtmlScopeReference;
 
 use super::HtmlAngularJsAnalyzer;
@@ -38,6 +38,11 @@ impl HtmlAngularJsAnalyzer {
 
     /// タグの属性からスコープ参照を抽出
     fn extract_scope_references_from_tag(&self, start_tag: Node, source: &str, uri: &Url) {
+        // 要素のタグ名を取得 (component bindings 判定で必要)
+        let element_tag_name = self
+            .find_child_by_kind(start_tag, "tag_name")
+            .map(|n| self.node_text(n, source));
+
         let mut cursor = start_tag.walk();
         for child in start_tag.children(&mut cursor) {
             if child.kind() == "attribute" {
@@ -53,8 +58,13 @@ impl HtmlAngularJsAnalyzer {
                         let value_byte_col = value_node.start_position().column + 1; // +1 for quote
                         let value_start_col = self.byte_col_to_utf16_col(source, value_start_line, value_byte_col);
 
-                        if is_ng_directive(&attr_name) {
-                            // ngディレクティブ: 属性値全体をAngular式として解析
+                        if is_directive_attribute(
+                            &attr_name,
+                            element_tag_name.as_deref(),
+                            &self.index,
+                        ) {
+                            // ngディレクティブ または custom directive / component binding:
+                            // 属性値全体をAngular式として解析
                             let property_paths = self.parse_angular_expression(value, &attr_name);
                             self.register_scope_references(uri, value, &property_paths, value_start_line as u32, value_start_col);
                         } else {

--- a/src/index/definition_store.rs
+++ b/src/index/definition_store.rs
@@ -62,6 +62,14 @@ impl DefinitionStore {
         self.definitions.contains_key(name)
     }
 
+    /// 指定した名前 + Kind の定義が存在するか
+    pub fn has_definition_of_kind(&self, name: &str, kind: SymbolKind) -> bool {
+        self.definitions
+            .get(name)
+            .map(|defs| defs.iter().any(|s| s.kind == kind))
+            .unwrap_or(false)
+    }
+
     pub fn get_references(&self, name: &str) -> Vec<SymbolReference> {
         self.references
             .get(name)

--- a/tests/angularjs_common_syntax_test.rs
+++ b/tests/angularjs_common_syntax_test.rs
@@ -2728,3 +2728,158 @@ angular.module('app', []).controller('PageCtrl', function() {
     assert_eq!(binding.controller_name, "AliasedDialogCtrl");
     assert_eq!(binding.source, BindingSource::MdDialog);
 }
+
+// ============================================================
+// custom directive / component bindings の attribute 値解析
+// ============================================================
+
+#[test]
+fn test_custom_directive_attribute_value_is_parsed_as_expression() {
+    // .directive('myHighlight', ...) で登録された directive の属性値が
+    // Angular 式として解析され、scope 参照が登録されること
+    let js = r#"
+angular.module('app', [])
+    .controller('Ctrl', ['$scope', function($scope) {
+        $scope.user = {};
+    }])
+    .directive('myHighlight', [function() {
+        return { restrict: 'A' };
+    }]);
+"#;
+    let html = r#"
+<div ng-controller="Ctrl">
+    <span my-highlight="user.name">label</span>
+</div>
+"#;
+    let index = analyze_html(js, html);
+    let html_uri = Url::parse("file:///test.html").unwrap();
+
+    let refs = index.html.get_html_scope_references(&html_uri);
+    // 既存パーサーは top-level identifier のみ拾う ("user.name" → "user")。
+    // ここでは「式として解析されること」を確認したいので "user" が拾われていれば OK
+    let names: Vec<&str> = refs.iter().map(|r| r.property_path.as_str()).collect();
+    assert!(
+        names.iter().any(|n| *n == "user"),
+        "custom directive 'my-highlight' の属性値が解析され 'user' が登録されるべき (refs: {:?})",
+        names
+    );
+}
+
+#[test]
+fn test_unregistered_attribute_does_not_parse_as_expression() {
+    // 登録されていない属性は Angular 式として解析されない (現状維持)
+    let js = r#"
+angular.module('app', []).controller('Ctrl', ['$scope', function($scope) {
+    $scope.user = {};
+}]);
+"#;
+    let html = r#"
+<div ng-controller="Ctrl">
+    <span data-foo="user.name">label</span>
+</div>
+"#;
+    let index = analyze_html(js, html);
+    let html_uri = Url::parse("file:///test.html").unwrap();
+
+    let refs = index.html.get_html_scope_references(&html_uri);
+    let names: Vec<&str> = refs.iter().map(|r| r.property_path.as_str()).collect();
+    assert!(
+        !names.iter().any(|n| *n == "user"),
+        "未登録 directive 'data-foo' の属性値は scope 参照として登録されるべきでない (refs: {:?})",
+        names
+    );
+}
+
+#[test]
+fn test_component_binding_attribute_value_is_parsed_as_expression() {
+    // .component('userCard', { bindings: { user: '<', onSelect: '&' } })
+    // で登録された binding 名と一致する属性値が Angular 式として解析される
+    let js = r#"
+angular.module('app', [])
+    .controller('Ctrl', ['$scope', function($scope) {
+        $scope.currentUser = {};
+        $scope.handleSelect = function() {};
+    }])
+    .component('userCard', {
+        templateUrl: 'card.html',
+        bindings: {
+            user: '<',
+            onSelect: '&'
+        }
+    });
+"#;
+    let html = r#"
+<div ng-controller="Ctrl">
+    <user-card user="currentUser" on-select="handleSelect()"></user-card>
+</div>
+"#;
+    let index = analyze_html(js, html);
+    let html_uri = Url::parse("file:///test.html").unwrap();
+
+    let refs = index.html.get_html_scope_references(&html_uri);
+    let names: Vec<&str> = refs.iter().map(|r| r.property_path.as_str()).collect();
+    assert!(
+        names.contains(&"currentUser"),
+        "<user-card user=\"currentUser\"> の 'currentUser' が scope 参照として登録されるべき (refs: {:?})",
+        names
+    );
+    assert!(
+        names.contains(&"handleSelect"),
+        "<user-card on-select=\"handleSelect()\"> の 'handleSelect' が scope 参照として登録されるべき (refs: {:?})",
+        names
+    );
+}
+
+#[test]
+fn test_component_unknown_binding_attribute_is_ignored() {
+    // component に存在しない binding 名の属性は Angular 式として解析されない
+    let js = r#"
+angular.module('app', [])
+    .controller('Ctrl', ['$scope', function($scope) { $scope.foo = 1; }])
+    .component('userCard', {
+        bindings: { user: '<' }
+    });
+"#;
+    let html = r#"
+<div ng-controller="Ctrl">
+    <user-card unknown-attr="foo"></user-card>
+</div>
+"#;
+    let index = analyze_html(js, html);
+    let html_uri = Url::parse("file:///test.html").unwrap();
+
+    let refs = index.html.get_html_scope_references(&html_uri);
+    let names: Vec<&str> = refs.iter().map(|r| r.property_path.as_str()).collect();
+    assert!(
+        !names.contains(&"foo"),
+        "未定義 binding 'unknown-attr' の属性値 'foo' は scope 参照として登録されるべきでない (refs: {:?})",
+        names
+    );
+}
+
+#[test]
+fn test_data_prefix_is_stripped_for_directive_lookup() {
+    // data- 接頭辞付きの custom directive も認識される
+    let js = r#"
+angular.module('app', [])
+    .controller('Ctrl', ['$scope', function($scope) {
+        $scope.x = 1;
+    }])
+    .directive('myDir', [function() { return {}; }]);
+"#;
+    let html = r#"
+<div ng-controller="Ctrl">
+    <span data-my-dir="x">label</span>
+</div>
+"#;
+    let index = analyze_html(js, html);
+    let html_uri = Url::parse("file:///test.html").unwrap();
+
+    let refs = index.html.get_html_scope_references(&html_uri);
+    let names: Vec<&str> = refs.iter().map(|r| r.property_path.as_str()).collect();
+    assert!(
+        names.contains(&"x"),
+        "data- prefix 付き custom directive の属性値も解析されるべき (refs: {:?})",
+        names
+    );
+}


### PR DESCRIPTION
## Summary
これまで HTML 属性値を Angular 式として解析するかは static set (`NG_DIRECTIVE_SET`) のみで判定していました。そのため、ユーザーが自分で `.directive()` で登録した属性や、`.component()` の `bindings` で宣言した属性の値は一切解析されず、`scope` 参照や `local variable` 参照として登録されない状態でした。

```html
<!-- これまで: my-highlight, on-select の属性値が解析されなかった -->
<span my-highlight="user.name">label</span>
<user-card user="currentUser" on-select="handleSelect()"></user-card>
```

## 修正方針
`is_ng_directive` を index 認識込みの `is_directive_attribute(attr_name, element_name, &Index)` に格上げし、以下のいずれかに該当する属性を Angular 式として扱うようにします：

| 判定 | ソース | 例 |
|---|---|---|
| 1. ビルトイン/既知ライブラリ | `NG_DIRECTIVE_SET` (既存) | `ng-click`, `uib-tooltip` |
| 2. **custom directive** | `SymbolKind::Directive` 検索 | `<span my-highlight="...">` |
| 3. **component binding** | `SymbolKind::ComponentBinding` 検索（element 名+attr 名で照合） | `<user-card on-select="...">` |

`data-` 接頭辞は剥がしてから index 検索します。

## Changes Made
- **`src/index/definition_store.rs`**: `has_definition_of_kind(name, kind)` を追加
- **`src/analyzer/html/directives.rs`**: `is_directive_attribute()` 新設（既存の `is_ng_directive` は内部で再利用）
- **`src/analyzer/html/scope_reference.rs`**: `extract_scope_references_from_tag` で `element_tag_name` を取得して新 API に渡す
- **`src/analyzer/html/local_variable.rs`**: 同様に `element_tag_name` を引き回す
- **`src/analyzer/html/expression.rs`**:
  - `is_in_angular_context`（補完判定）でも element 名を抽出して新 API を使う
  - `extract_element_name_before` ヘルパー追加（カーソル位置のテキストから直近の `<tag` を抽出）

`directive_reference.rs` は「ビルトインを除外して custom 候補だけを directive 参照に登録する」用途なので変更不要（残置）。

## Test plan
- [x] 新規テスト 5件すべて通過
  - custom directive の属性値が解析される
  - 未登録属性は解析されない（誤検出防止）
  - component bindings 名と一致する属性値が解析される
  - 未定義 binding 名の属性は解析されない
  - `data-` プレフィックス付きでも認識される
- [x] 既存テスト全件通過（合計245件）

## 残課題（別 PR 候補）
- ネストプロパティ参照（`user.name` の `.name` まで含めて記録）— 今回は base 名 (`user`) までで停止。UNSUPPORTED #13 系で別途扱う
- `restrict: 'A'` の解析 — element-only directive を attribute と誤認しない厳密化。実用では低優先（誤認しても Angular が無視するので実害小）

🤖 Generated with [Claude Code](https://claude.com/claude-code)