### PR TITLE
fix: 一部ファイルでセマンティックハイライトが効かなくなる問題を修正

### DIFF
--- a/src/handler/semantic_tokens.rs
+++ b/src/handler/semantic_tokens.rs
@@ -263,18 +263,57 @@ impl SemanticTokensHandler {
     }
 
     /// Encode raw tokens as delta-encoded SemanticTokens
+    ///
+    /// LSP semantic tokens spec の制約:
+    /// - tokens は (line, start_col) 昇順でソート済みであること
+    /// - tokens は重複/オーバーラップしてはならない
+    /// - length > 0 でなければならない
+    ///
+    /// この LSP は複数のソース (scope refs / local vars / form bindings /
+    /// directive refs) からトークンを集めるため、同一スパンの重複や
+    /// 隣接トークンのオーバーラップが発生し得る。クライアント (VS Code 等) は
+    /// オーバーラップ等の不正データを検出すると **ファイル全体の semantic
+    /// tokens を破棄して何も表示しない** ため、ここで防御的に弾く。
     fn encode_tokens(mut raw_tokens: Vec<RawSemanticToken>) -> Vec<SemanticToken> {
-        // Sort by line, then by column
-        raw_tokens.sort_by(|a, b| a.line.cmp(&b.line).then(a.start_col.cmp(&b.start_col)));
+        // 1. length=0 の不正トークンを除外
+        raw_tokens.retain(|t| t.length > 0);
+
+        // 2. (line, start_col, -length) でソート
+        //    同一 (line, col) の場合は length が大きいものを先に置く
+        //    (後段の overlap dedup で長い方を残せるように)
+        raw_tokens.sort_by(|a, b| {
+            a.line
+                .cmp(&b.line)
+                .then(a.start_col.cmp(&b.start_col))
+                .then(b.length.cmp(&a.length))
+        });
 
         let mut encoded = Vec::new();
         let mut prev_line = 0u32;
         let mut prev_col = 0u32;
+        let mut prev_end_col = 0u32; // 直前トークンの右端 (overlap 検出用)
+        let mut first = true;
 
         for token in raw_tokens {
-            let delta_line = token.line - prev_line;
+            // 3. 直前トークンと完全に同じスパンならスキップ (重複)
+            if !first
+                && token.line == prev_line
+                && token.start_col == prev_col
+                && token.start_col + token.length == prev_end_col
+            {
+                continue;
+            }
+
+            // 4. 直前トークンと overlap (同一行で前トークンの右端より前で開始)
+            //    する場合はスキップ。これがあると VS Code が全 tokens を
+            //    破棄してハイライトが消える。
+            if !first && token.line == prev_line && token.start_col < prev_end_col {
+                continue;
+            }
+
+            let delta_line = token.line.saturating_sub(prev_line);
             let delta_start = if delta_line == 0 {
-                token.start_col - prev_col
+                token.start_col.saturating_sub(prev_col)
             } else {
                 token.start_col
             };
@@ -289,8 +328,98 @@ impl SemanticTokensHandler {
 
             prev_line = token.line;
             prev_col = token.start_col;
+            prev_end_col = token.start_col + token.length;
+            first = false;
         }
 
         encoded
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn raw(line: u32, start_col: u32, length: u32, token_type: u32) -> RawSemanticToken {
+        RawSemanticToken {
+            line,
+            start_col,
+            length,
+            token_type,
+            token_modifiers: 0,
+        }
+    }
+
+    #[test]
+    fn encode_tokens_skips_zero_length() {
+        let tokens = vec![raw(0, 0, 0, 0), raw(0, 5, 3, 0)];
+        let encoded = SemanticTokensHandler::encode_tokens(tokens);
+        assert_eq!(encoded.len(), 1, "length=0 のトークンは除外されるべき");
+        assert_eq!(encoded[0].delta_start, 5);
+        assert_eq!(encoded[0].length, 3);
+    }
+
+    #[test]
+    fn encode_tokens_skips_exact_duplicate_span() {
+        // 同一スパンが2回現れた場合、片方だけが残る
+        let tokens = vec![raw(2, 5, 4, 0), raw(2, 5, 4, 1)];
+        let encoded = SemanticTokensHandler::encode_tokens(tokens);
+        assert_eq!(encoded.len(), 1, "完全に同じスパンの重複は1つに集約されるべき");
+    }
+
+    #[test]
+    fn encode_tokens_skips_overlapping_tokens() {
+        // [5,10) と [7,12) が overlap → 後者をスキップ
+        // (overlap があるとクライアントが全トークン破棄するので必ず除外)
+        let tokens = vec![raw(2, 5, 5, 0), raw(2, 7, 5, 1)];
+        let encoded = SemanticTokensHandler::encode_tokens(tokens);
+        assert_eq!(
+            encoded.len(),
+            1,
+            "オーバーラップトークンの後者はスキップされるべき"
+        );
+        assert_eq!(encoded[0].delta_start, 5);
+        assert_eq!(encoded[0].length, 5);
+    }
+
+    #[test]
+    fn encode_tokens_keeps_adjacent_non_overlapping() {
+        // [5,8) と [8,12) は隣接だが overlap しない → 両方残す
+        let tokens = vec![raw(2, 5, 3, 0), raw(2, 8, 4, 1)];
+        let encoded = SemanticTokensHandler::encode_tokens(tokens);
+        assert_eq!(encoded.len(), 2, "隣接トークンは両方残るべき");
+        assert_eq!(encoded[0].delta_start, 5);
+        assert_eq!(encoded[1].delta_line, 0);
+        assert_eq!(encoded[1].delta_start, 3);
+    }
+
+    #[test]
+    fn encode_tokens_correct_delta_encoding() {
+        // 複数行にまたがる正常ケース
+        let tokens = vec![raw(1, 2, 3, 0), raw(1, 10, 4, 1), raw(3, 5, 2, 2)];
+        let encoded = SemanticTokensHandler::encode_tokens(tokens);
+        assert_eq!(encoded.len(), 3);
+        // 1行目, col=2, len=3
+        assert_eq!(encoded[0].delta_line, 1);
+        assert_eq!(encoded[0].delta_start, 2);
+        assert_eq!(encoded[0].length, 3);
+        // 同じ行 (delta_line=0), col=10 なので delta_start=8
+        assert_eq!(encoded[1].delta_line, 0);
+        assert_eq!(encoded[1].delta_start, 8);
+        // 行が変わったので delta_start は絶対値
+        assert_eq!(encoded[2].delta_line, 2);
+        assert_eq!(encoded[2].delta_start, 5);
+    }
+
+    #[test]
+    fn encode_tokens_unsorted_input_is_normalized() {
+        // 入力が順不同でも正しくソート→エンコードされる
+        let tokens = vec![raw(3, 5, 2, 0), raw(1, 10, 4, 1), raw(1, 2, 3, 2)];
+        let encoded = SemanticTokensHandler::encode_tokens(tokens);
+        assert_eq!(encoded.len(), 3);
+        // 最初が (1,2,3) であること
+        assert_eq!(encoded[0].delta_line, 1);
+        assert_eq!(encoded[0].delta_start, 2);
+        assert_eq!(encoded[0].length, 3);
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -412,6 +412,12 @@ impl Backend {
 
             self.publish_diagnostics_for_html(&uri).await;
             self.republish_diagnostics_for_open_js_files().await;
+
+            // クライアントが on_open 完了前に semantic_tokens_full を要求した場合、
+            // 空トークンが返ってハイライトが永続的に消えるレースを防ぐ。
+            // 解析完了をクライアントに通知して再要求させる。
+            let _ = self.client.semantic_tokens_refresh().await;
+            let _ = self.client.code_lens_refresh().await;
         } else if is_js_file(&uri) {
             self.debounce_versions.insert(uri.clone(), 0);
 
@@ -425,6 +431,10 @@ impl Backend {
             .unwrap_or(());
 
             self.publish_diagnostics_for_js(&uri).await;
+
+            // (HTML側と同じ理由) JS ファイルでも解析後に refresh を送る
+            let _ = self.client.semantic_tokens_refresh().await;
+            let _ = self.client.code_lens_refresh().await;
         }
 
         // tsserver は JS ファイルだけ知っていれば良い (HTML は内部ハンドラで処理)


### PR DESCRIPTION
## Summary
"たまにシンタックスハイライトが全く効かないファイルが出てくる" 報告の調査と修正です。**2つの根本原因**を併せて解消します。

## 原因1: `on_open` 後の `semantic_tokens_refresh` 漏れ (race condition)

**現象**: クライアントが `didOpen` 通知を送った直後 (= まだ `on_open` の解析が完了する前) に `semantic_tokens_full` を要求するケースがあります。tower-lsp は notification と request を並行 dispatch するので、解析完了前に semantic_tokens ハンドラが先に走ることがあり、そのとき index にシンボルが無く **空トークン**が返ります。

`on_change` 経路では完了後に `semantic_tokens_refresh` を送っていましたが、`on_open` では送っていなかったため、クライアントは empty を受け取ったまま **永続的にハイライトが消える状態** になっていました（次に編集するまで戻らない）。

**修正**: `on_open` の HTML/JS 両経路で、解析完了後に `semantic_tokens_refresh` + `code_lens_refresh` を送る。

## 原因2: `encode_tokens` の防御不足 (overlap/重複/0長)

**現象**: LSP semantic tokens spec はトークンの overlap を禁止しており、違反するとクライアント (VS Code 等) は**ファイル全体の semantic tokens を破棄**して何も表示しなくなります。本 LSP は scope refs / local vars / form bindings / directive refs の複数ソースから集めるため、稀に同一スパン重複や overlap が起きうる構造でした。

**修正**: `encode_tokens` で以下を弾く：
- `length=0` (zero-width) トークン
- 完全に同一スパンの重複
- 直前トークンと overlap する (`start_col < prev_end_col`) トークン
- delta 計算は `saturating_sub` で念のため overflow ガード

## Changes Made
- **`src/server/mod.rs`**: `on_open` の HTML/JS 解析後に `semantic_tokens_refresh` / `code_lens_refresh` を呼ぶよう追加
- **`src/handler/semantic_tokens.rs`**:
  - `encode_tokens` を防御的にリファクタ
  - 重複/オーバーラップ/0長トークンをスキップ
  - sort 時に同 (line,col) は length 大を先頭にして overlap dedup を最大化
  - ユニットテスト 6件追加（unit 全 76 件）

## Test plan
- [x] 新規ユニットテスト 6件すべて通過
- [x] 既存テスト全件通過（合計251件）
- [ ] 実プロジェクトで「ハイライトが効かないファイル」が再現しなくなることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)