### PR TITLE
perf: 定義取得を URI 逆引きで O(該当ファイルのシンボル数) 化

### DIFF
--- a/docs/performance-improvements.md
+++ b/docs/performance-improvements.md
@@ -1,0 +1,165 @@
+# ファイル更新時の処理パフォーマンス改善候補
+
+`textDocument/didOpen` / `didChange` / `didSave` を起点とした解析パイプラインにおいて、現状把握できている非効率・冗長・取りこぼしリスクのある箇所をまとめる。
+
+各項目は以下の構成:
+
+- **該当箇所**: 主要なファイルパスと行番号
+- **問題**: 何が起きているか
+- **改善案**: 具体的な書き換え方針
+- **影響度 / 改修難度**
+
+優先度の付け方: 「ファイル更新ごとに毎回走るコスト」「依存深さに比例して悪化するコスト」が高いものを High、効くが影響範囲が限定的なものを Medium、クリーンアップ系を Low とする。
+
+---
+
+## High
+
+### #1 `get_definitions_for_uri` / `get_scope_definitions_for_js` が DashMap 全件走査 ✅ 対応済み
+
+- **該当箇所**: `src/index/definition_store.rs`
+  - 呼び出し元: `src/server/mod.rs:232-235`(HTML on_change), `src/server/mod.rs:330-344`(JS on_change before/after), `src/handler/diagnostics.rs:check_unused_scope_variables`, `src/index/query.rs:292`
+- **問題 (対応前)**:
+  - シンボル名 → `Vec<Symbol>` の `definitions: DashMap<String, Vec<Symbol>>` を**全エントリ走査**し、`Vec<Symbol>` を毎回 clone してから URI で絞り込んでいた
+  - 毎キーストロークごと (debounce 後)、JS 編集では before/after の **2 回**呼ばれる
+  - シンボル数が増えるほど線形にコストが上がる (編集中ファイルの大きさではなく**ワークスペース全体のシンボル数**に比例)
+  - `document_symbols: DashMap<Url, Vec<String>>` という URI 逆引きが既に存在していたのに使っていなかった
+- **対応**:
+  - 新ヘルパー `collect_definitions_for_uri(uri, predicate)` を導入し、`document_symbols.get(uri)` で候補名リストを取り、各 name について `definitions.get(name)` → URI / `predicate` フィルタ、という **O(該当ドキュメントのシンボル数)** 実装に置き換えた
+  - `get_definitions_for_uri` は `predicate = |_| true`、`get_scope_definitions_for_js` は kind フィルタを `predicate` に渡すだけで合流
+  - 呼び出し元のシグネチャは変えていないので、既存の利用箇所はそのまま高速化された
+  - 単体テスト追加: `get_definitions_for_uri_returns_only_target_uri`, `get_scope_definitions_for_js_filters_by_kind`
+  - 同時に #10 も解決 (`document_symbols` を `HashSet<String>` 化)
+- **影響度**: 大 (毎更新の常時コスト) / **改修難度**: 中
+
+### #2 `republish_all_js_diagnostics` が「開いている JS 全部」
+
+- **該当箇所**: `src/server/mod.rs:76-91, 277-283`
+- **問題**:
+  - HTML 更新時、embedded `<script>` の有無で発火条件は絞られているが、発火したら**開いている JS ファイル全部**を再診断する
+  - 実際に診断結果が変わり得るのは「変更された HTML が参照する scope シンボルを定義している JS」だけのはず
+  - JS 側には `collect_affected_html_uris` 相当の絞り込み関数が無い
+- **改善案**:
+  - JS 用の影響範囲計算 `collect_affected_js_uris(changed_html_uri)` を追加する
+  - 算出根拠: 変更前後の HTML の `$scope` 参照名集合の和 → それらを定義している JS URI を `definitions` 経由で逆引き(または `document_symbols` の逆引き)
+- **影響度**: 中 (大量の JS を開いている環境ほど顕著) / **改修難度**: 中
+
+### #3 `collect_affected_html_uris` の参照ルックアップで全件 clone
+
+- **該当箇所**: `src/server/mod.rs:106-135`, 内部呼出 `src/index/definition_store.rs:73`(`get_references`)
+- **問題**:
+  - `get_references(name)` は `Vec<SymbolReference>::clone()` を返すので、**開いていない HTML のリファレンスも一旦丸ごと clone してから捨てている**
+  - JS 編集時に `before ∪ after` の各シンボル名で呼び出されるため、シンボル変化が大きいリネーム等で膨らむ
+- **改善案**:
+  - `for_each_reference(name, |r| …) -> bool` 形式の borrowing API を `DefinitionStore` に追加し、HTML 該当時点で early return / 早期判定する
+  - もしくは `references_by_uri: DashMap<Url, Vec<SymbolReference>>` の逆引きインデックスを追加する
+- **影響度**: 中 / **改修難度**: 中
+
+### #4 `take_pending_reanalysis` の単発消費 — 取りこぼし & 1 段までしか追わない
+
+- **該当箇所**: `src/index/template_store.rs:679-681`, `src/server/mod.rs:249-263`
+- **問題**:
+  1. `take` した直後に `analyze_document` 内で panic / 失敗すると、pending エントリが消失して二度と再解析されない
+  2. 子の再解析中に**孫**が新たに `add_pending_reanalysis()` されても、その同じラウンドでは消費されない (ループ化されていない)
+  3. 子の再解析パスで `analyze_document()` を呼んでおり、親の Tree を流用せずに**再パース**している (#7 とも関連)
+- **改善案**:
+  - `while !pending.is_empty()` でドレインするループ構造にする (深さ上限 / 重複検知付き)
+  - 取り出し → 失敗 → pending に戻す、もしくは「処理中セット」と「pending セット」を分ける
+  - 親パスで作った Tree を流用するパス (`analyze_document_with_tree` の公開化) を子側でも使う
+- **影響度**: 中 (`ng-include` 依存が深いプロジェクトで顕著) / **改修難度**: 中
+
+---
+
+## Medium
+
+### #5 `clear_document` が必要以上に消す
+
+- **該当箇所**: `src/analyzer/html/mod.rs:81-96` (`analyze_document_with_tree` 冒頭で `index.clear_document(uri)`)
+  - 比較対象: `analyze_document_references_only_with_tree` (`html/mod.rs:110-112`) は `clear_html_references` のみ
+- **問題**:
+  - `clear_document` は 6 ストア (definitions / controllers / templates / html / exports / components) 全部を消してから Pass 1〜3 を再実行する
+  - 実際には HTML の編集で変わるのは大半が Pass 3 (scope 参照) のみ
+  - Pass 1 (ng-controller) / 1.5 (ng-include) / 2 (form bindings) の出力が変わらないケースでも全消しになる
+- **改善案**:
+  - `clear_document` を「ストア別に消すか選べる」API に分割する
+  - もしくは Pass 1/1.5/2 の出力をハッシュ等で差分判定し、変化がなければ該当ストアの clear と再投入をスキップ
+- **影響度**: 中 / **改修難度**: 中
+
+### #6 `semantic_tokens_refresh` / `code_lens_refresh` を無条件発火
+
+- **該当箇所**: `src/server/mod.rs:286-287, 363-364, 419-420, 436-437`
+- **問題**:
+  - LSP 仕様上 `semanticTokens/refresh` は**クライアントが開いている全ファイル分** `semanticTokens/full` を再リクエストさせる
+  - HTML を 1 ファイル編集するだけで開いている HTML × N に対するリクエストが返ってくる構造
+  - JS 編集時の `semantic_tokens_refresh` は、シンボル名集合に変化がなければ HTML 側のトークンも変わらないため不要
+  - `code_lens_refresh` は JS 側の意味付けが主なので、HTML 編集時には不要なことが多い
+- **改善案**:
+  - JS パス: `before_symbols == after_symbols` のときは両 refresh をスキップ
+  - HTML パス: embedded script 有無や scope 参照集合に変化があったときだけ `semantic_tokens_refresh`、`code_lens_refresh` は基本省略
+- **影響度**: 中 (体感レイテンシ) / **改修難度**: 小
+
+### #7 HTML パース重複 (`analyze_document` vs `analyze_document_and_extract_scripts`)
+
+- **該当箇所**: `src/analyzer/html/mod.rs:61-78`, 利用側 `src/server/mod.rs:261`
+- **問題**:
+  - 通常パスは `analyze_document_and_extract_scripts` (Tree を 1 回パースして使い回す) で済んでいる
+  - だが pending 子テンプレートの再解析 (`server/mod.rs:261`) は `analyze_document` 経由なので、親と独立に**再パース**している
+  - `analyze_document_with_tree` は `pub(self)` 相当でクレート外に出ていない (現状 `fn`)
+- **改善案**:
+  - `analyze_document_with_tree` を呼び出し可能にして、親側で作った Tree (または子用に新規パースした Tree) を使い回せる経路を 1 つに統一
+  - `analyze_document` 系の API を整理し、薄い wrapper だけにする
+- **影響度**: 小 / **改修難度**: 小
+
+### #8 tsserver への `did_change` が debounce されない
+
+- **該当箇所**: `src/server/mod.rs:369-375`
+- **問題**:
+  - 解析パイプラインは 200ms debounce しているのに、`ts_proxy.did_change` は `on_change` 末尾で**毎キーストローク**呼ばれている
+  - tsserver 側にも内部処理があるとはいえ、IPC とテキスト送信のオーバーヘッドが無駄に増える
+  - `version` も常に `0` (`did_save` 経路) または引数 version で渡されている
+- **改善案**:
+  - debounce 後の `tokio::spawn` ブロック内に `ts_proxy.did_change` を移動する
+  - もしくは `debounce_versions` を共有して「最終キー入力からアイドル後にだけ送る」キューを作る
+- **影響度**: 小 / **改修難度**: 小
+
+---
+
+## Low
+
+### #9 `clone()` の連鎖 — Symbol / Vec / String
+
+- **該当箇所**: `src/index/definition_store.rs` 各 getter, `src/index/html_store.rs:60-64` ほか
+- **問題**:
+  - `get_definitions_for_uri`, `get_scope_definitions_for_js`, `get_html_scope_references` などが軒並み `Vec<…>::clone()` を返す
+  - ホットパス上にある (`on_change` 内) ためピーク時のヒープ確保量が大きい
+- **改善案**:
+  - `Symbol` を `Arc<Symbol>` 化し、ストア内も外も共有参照で済ます
+  - もしくは `for_each_*` パターンで内部反復して、呼び出し側で必要なものだけ name 等を取り出す
+- **影響度**: 小 (体感には出にくいが GC アロケータ圧は減る) / **改修難度**: 小
+
+### #10 `add_definition` / `add_reference` が `document_symbols` に重複 push ✅ 対応済み
+
+- **該当箇所**: `src/index/definition_store.rs`
+- **問題 (対応前)**:
+  - `definitions` 側には is_duplicate チェックがあるが、`document_symbols` 側には無かった
+  - 同じ name が同じ URI で複数回現れると、`document_symbols.get(uri)` の `Vec<String>` に重複が積まれる
+  - `document_symbols` を読み取り口として使っていなかったので顕在化していなかったが、#1 で逆引き活用するときに必ず踏むため先回りで解決
+- **対応**:
+  - `document_symbols` の値型を `Vec<String>` → `HashSet<String>` に変更し、`add_definition` / `add_reference` での `.push` を `.insert` に置き換え
+  - `clear_document` の `for symbol_name in symbols` は HashSet の IntoIterator でそのまま動くため改修不要
+  - 単体テスト追加: `document_symbols_dedupes_repeated_adds` (同じ name が定義 2 件 + 参照 1 件で add されても `document_symbols` には 1 件のみ)
+- **影響度**: 小 (#1 の前提条件) / **改修難度**: 小
+
+---
+
+## 推奨着手順
+
+| 順 | 項目 | 主効果 | 状態 |
+|----|------|--------|------|
+| 1 | #1 + #10 — `document_symbols` を活用した URI 逆引き | 毎更新の常時コストを大きく削減 | ✅ 対応済み |
+| 2 | #6 — refresh をシンボル変化時のみに絞る | 体感レイテンシ改善 | 未対応 |
+| 3 | #4 + #7 — pending_reanalysis のループ化と Tree 再利用 | 依存深いテンプレで効く | 未対応 |
+| 4 | #2 — JS 単位の影響範囲計算 | 大量 JS を開く環境で効く | 未対応 |
+| 5 | #5 — `clear_document` の選択的分割 | 中規模 HTML で効く | 未対応 |
+| 6 | #8 — tsserver `did_change` の debounce | IPC トラフィック削減 | 未対応 |
+| 7 | #3 / #9 — borrowing API・`Arc` 化 | アロケーション圧削減 | 未対応 |

--- a/src/index/definition_store.rs
+++ b/src/index/definition_store.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use dashmap::DashMap;
 use tower_lsp::lsp_types::Url;
 
@@ -7,7 +9,10 @@ use crate::model::{Symbol, SymbolKind, SymbolReference};
 pub struct DefinitionStore {
     definitions: DashMap<String, Vec<Symbol>>,
     references: DashMap<String, Vec<SymbolReference>>,
-    document_symbols: DashMap<Url, Vec<String>>,
+    /// URI → そのドキュメントから add された定義/参照のシンボル名集合。
+    /// `get_definitions_for_uri` 等の URI 逆引きを O(該当ドキュメントのシンボル数)
+    /// で行うためのインデックス。重複登録を避けるため HashSet で保持する。
+    document_symbols: DashMap<Url, HashSet<String>>,
 }
 
 impl DefinitionStore {
@@ -31,7 +36,7 @@ impl DefinitionStore {
         });
         if !is_duplicate {
             entry.push(symbol);
-            self.document_symbols.entry(uri).or_default().push(name);
+            self.document_symbols.entry(uri).or_default().insert(name);
         }
     }
 
@@ -47,7 +52,7 @@ impl DefinitionStore {
         });
         if !is_duplicate {
             entry.push(reference);
-            self.document_symbols.entry(uri).or_default().push(name);
+            self.document_symbols.entry(uri).or_default().insert(name);
         }
     }
 
@@ -96,14 +101,9 @@ impl DefinitionStore {
 
     /// 指定JSファイルの全スコープ変数定義を取得
     pub fn get_scope_definitions_for_js(&self, uri: &Url) -> Vec<Symbol> {
-        self.definitions
-            .iter()
-            .flat_map(|entry| entry.value().clone())
-            .filter(|s| {
-                &s.uri == uri
-                    && (s.kind == SymbolKind::ScopeProperty || s.kind == SymbolKind::ScopeMethod)
-            })
-            .collect()
+        self.collect_definitions_for_uri(uri, |s| {
+            s.kind == SymbolKind::ScopeProperty || s.kind == SymbolKind::ScopeMethod
+        })
     }
 
     /// 参照のみ存在するシンボル名を取得（定義がないもの）
@@ -191,11 +191,30 @@ impl DefinitionStore {
 
     /// 指定URIのドキュメント内定義を取得
     pub fn get_definitions_for_uri(&self, uri: &Url) -> Vec<Symbol> {
-        self.definitions
-            .iter()
-            .flat_map(|entry| entry.value().clone())
-            .filter(|s| &s.uri == uri)
-            .collect()
+        self.collect_definitions_for_uri(uri, |_| true)
+    }
+
+    /// `document_symbols` の URI 逆引きを使い、`definitions` を全件走査せずに
+    /// 当該ドキュメントの定義だけ取り出す。`predicate` が true の Symbol のみ
+    /// 返す。
+    fn collect_definitions_for_uri<F>(&self, uri: &Url, predicate: F) -> Vec<Symbol>
+    where
+        F: Fn(&Symbol) -> bool,
+    {
+        let Some(names) = self.document_symbols.get(uri) else {
+            return Vec::new();
+        };
+        let mut result = Vec::new();
+        for name in names.value() {
+            if let Some(entry) = self.definitions.get(name) {
+                for symbol in entry.value() {
+                    if &symbol.uri == uri && predicate(symbol) {
+                        result.push(symbol.clone());
+                    }
+                }
+            }
+        }
+        result
     }
 
     pub fn clear_document(&self, uri: &Url) {
@@ -330,5 +349,127 @@ mod tests {
         // （これがなければ get_reference_only_names で他の reference-only も誤判定する）
         assert!(!store.has_definition("Ctrl.$scope.mochi"));
         assert!(store.get_reference_only_names().is_empty());
+    }
+
+    #[test]
+    fn get_definitions_for_uri_returns_only_target_uri() {
+        let store = DefinitionStore::new();
+        let uri_a = Url::parse("file:///a.js").unwrap();
+        let uri_b = Url::parse("file:///b.js").unwrap();
+
+        store.add_definition(make_definition("Ctrl.$scope.foo", &uri_a));
+        store.add_definition(make_definition("Ctrl.$scope.bar", &uri_a));
+        store.add_definition(make_definition("Ctrl.$scope.shared", &uri_a));
+        store.add_definition(make_definition("Ctrl.$scope.shared", &uri_b));
+
+        let mut names: Vec<String> = store
+            .get_definitions_for_uri(&uri_a)
+            .into_iter()
+            .map(|s| s.name)
+            .collect();
+        names.sort();
+        assert_eq!(
+            names,
+            vec![
+                "Ctrl.$scope.bar".to_string(),
+                "Ctrl.$scope.foo".to_string(),
+                "Ctrl.$scope.shared".to_string(),
+            ]
+        );
+
+        let names_b: Vec<String> = store
+            .get_definitions_for_uri(&uri_b)
+            .into_iter()
+            .map(|s| s.name)
+            .collect();
+        assert_eq!(names_b, vec!["Ctrl.$scope.shared".to_string()]);
+    }
+
+    #[test]
+    fn get_scope_definitions_for_js_filters_by_kind() {
+        let store = DefinitionStore::new();
+        let uri = make_uri();
+
+        let span = Span::new(0, 0, 0, 4);
+        let scope_prop =
+            SymbolBuilder::new("Ctrl.$scope.x".to_string(), SymbolKind::ScopeProperty, uri.clone())
+                .definition_span(span)
+                .name_span(span)
+                .build();
+        let scope_method = SymbolBuilder::new(
+            "Ctrl.$scope.fn".to_string(),
+            SymbolKind::ScopeMethod,
+            uri.clone(),
+        )
+        .definition_span(Span::new(1, 0, 1, 2))
+        .name_span(Span::new(1, 0, 1, 2))
+        .build();
+        let controller =
+            SymbolBuilder::new("Ctrl".to_string(), SymbolKind::Controller, uri.clone())
+                .definition_span(Span::new(2, 0, 2, 4))
+                .name_span(Span::new(2, 0, 2, 4))
+                .build();
+
+        store.add_definition(scope_prop);
+        store.add_definition(scope_method);
+        store.add_definition(controller);
+
+        let mut names: Vec<String> = store
+            .get_scope_definitions_for_js(&uri)
+            .into_iter()
+            .map(|s| s.name)
+            .collect();
+        names.sort();
+        assert_eq!(
+            names,
+            vec!["Ctrl.$scope.fn".to_string(), "Ctrl.$scope.x".to_string()]
+        );
+    }
+
+    #[test]
+    fn document_symbols_dedupes_repeated_adds() {
+        // 同じ name に対して複数の定義/参照が登録されても、document_symbols 側
+        // には 1 度だけ含まれるべき (URI 逆引きで同じ name を何度も
+        // definitions.get() しないようにするため)
+        let store = DefinitionStore::new();
+        let uri = make_uri();
+
+        // 定義側: 異なる span で 2 回登録 (どちらも有効な定義として残る)
+        let def1 = SymbolBuilder::new(
+            "Ctrl.$scope.x".to_string(),
+            SymbolKind::ScopeProperty,
+            uri.clone(),
+        )
+        .definition_span(Span::new(0, 0, 0, 1))
+        .name_span(Span::new(0, 0, 0, 1))
+        .build();
+        let def2 = SymbolBuilder::new(
+            "Ctrl.$scope.x".to_string(),
+            SymbolKind::ScopeProperty,
+            uri.clone(),
+        )
+        .definition_span(Span::new(2, 0, 2, 1))
+        .name_span(Span::new(2, 0, 2, 1))
+        .build();
+        store.add_definition(def1);
+        store.add_definition(def2);
+
+        // 同じ name で参照も登録
+        store.add_reference(SymbolReference {
+            name: "Ctrl.$scope.x".to_string(),
+            uri: uri.clone(),
+            span: Span::new(3, 0, 3, 1),
+        });
+
+        // document_symbols には "Ctrl.$scope.x" が 1 度だけ入っているべき
+        let entry = store
+            .document_symbols
+            .get(&uri)
+            .expect("uri entry exists");
+        assert_eq!(entry.value().len(), 1);
+        assert!(entry.value().contains("Ctrl.$scope.x"));
+
+        // 一方で definitions 側には 2 件残っている
+        assert_eq!(store.get_definitions("Ctrl.$scope.x").len(), 2);
     }
 }


### PR DESCRIPTION
## Summary

- `get_definitions_for_uri` / `get_scope_definitions_for_js` を `definitions: DashMap<String, Vec<Symbol>>` の全件走査から、`document_symbols` (URI → name 集合) を使った逆引きに変更し、**O(ワークスペース全体のシンボル数) → O(該当ドキュメントのシンボル数)** に削減
- `document_symbols` の値型を `Vec<String>` → `HashSet<String>` に変えて、同じ name の重複 push を排除
- 改善ロードマップ `docs/performance-improvements.md` を追加 (本対応分は「対応済み」マーク付き)

## なぜ

`textDocument/didChange` のたびに走るホットパスで、これら getter は実質「全シンボル DashMap を iterate → `Vec<Symbol>` を毎回 clone → URI で filter」していた。JS 編集時は `before_symbols` / `after_symbols` の比較で **1 回の更新につき 2 回**呼ばれるため、ワークスペース規模が大きいほど線形に遅くなる構造。

`document_symbols` という URI → name の逆引きインデックスはすでに `add_definition` / `add_reference` で構築されていたが、読み取り側で活用されていなかった。新ヘルパー `collect_definitions_for_uri(uri, predicate)` を介してこれを利用する形に統一。

呼び出し元 (`server/mod.rs:234,332,341`, `handler/diagnostics.rs:71`, `index/query.rs:292`) はシグネチャ非変更でそのまま高速化される。

## 変更ファイル

- `src/index/definition_store.rs` — 実装変更 + 単体テスト 3 件追加
- `docs/performance-improvements.md` — 改善ロードマップ (新規)

## Test plan

- [x] `cargo test --lib index::definition_store` — 既存 4 + 新規 3 = 7 件すべて pass
- [x] `cargo test` フルスイート — 79 + 79 + 113 + 2 件すべて pass (リグレッションなし)
- [ ] 大規模プロジェクトを開いた状態でファイル編集時のレイテンシを目視確認 (任意)

新規テスト:
- `get_definitions_for_uri_returns_only_target_uri` — 別 URI の定義が混ざっていても自分の定義だけ返す
- `get_scope_definitions_for_js_filters_by_kind` — Controller 等を除き ScopeProperty/ScopeMethod のみ返す
- `document_symbols_dedupes_repeated_adds` — 同じ name が定義 2 件 + 参照 1 件で add されても `document_symbols` には 1 件のみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)