### PR TITLE
fix: HTML補完で `$scope.X` (Method) と `X` (Function) の重複を解消

### DIFF
--- a/src/handler/completion.rs
+++ b/src/handler/completion.rs
@@ -185,11 +185,27 @@ impl CompletionHandler {
 
                 items
             } else {
-                // サービス名が指定された場合、そのサービスのメソッドのみを返す
+                // サービス名/コントローラー名が指定された場合、そのプレフィックスを持つ
+                // メソッド (service の `.method()` や controller の `this.X`) のみを返す。
+                //
+                // `MyCtrl.$scope.foo` や `MyCtrl.$rootScope.foo` も name 上は
+                // `MyCtrl.` で始まるが、これらは別途 `$scope` / `$rootScope`
+                // プレフィックス分岐で扱う候補なので、ここでは除外する
+                // (HTML 補完で `update` (Function) と `$scope.update` (Method) が
+                //  同時に出る重複の原因となるため)。
                 let method_prefix = format!("{}.", prefix);
                 definitions
                     .into_iter()
-                    .filter(|s| s.name.starts_with(&method_prefix))
+                    .filter(|s| {
+                        s.name.starts_with(&method_prefix)
+                            && !matches!(
+                                s.kind,
+                                SymbolKind::ScopeProperty
+                                    | SymbolKind::ScopeMethod
+                                    | SymbolKind::RootScopeProperty
+                                    | SymbolKind::RootScopeMethod
+                            )
+                    })
                     .map(|symbol| {
                         // "ServiceName.methodName" から "methodName" だけを抽出
                         let method_name = symbol

--- a/tests/angularjs_common_syntax_test.rs
+++ b/tests/angularjs_common_syntax_test.rs
@@ -2883,3 +2883,76 @@ angular.module('app', [])
         names
     );
 }
+
+#[test]
+fn test_controller_prefix_completion_excludes_scope_methods() {
+    // controller 名をプレフィックスにした補完 (HTML 内で controller の this.X を
+    // 拾うため `complete_with_context(Some("CtrlName"), ...)` を呼ぶ経路) で
+    // `$scope.X` が "$scope.X" というラベルで Method として混入してはいけない。
+    //
+    // バグ前は `MyCtrl.$scope.update` も name が `MyCtrl.` で始まるため
+    // strip_prefix されて `$scope.update` (Method) として返ってきていた。
+    use angularjs_lsp::handler::CompletionHandler;
+    use tower_lsp::lsp_types::CompletionResponse;
+
+    let js = r#"
+angular.module('app', []).controller('MyCtrl', ['$scope', function($scope) {
+    var vm = this;
+    vm.refresh = function() {};
+    $scope.update = function() {};
+}]);
+"#;
+    let index = analyze_js(js);
+    let handler = CompletionHandler::new(index);
+
+    let resp = handler
+        .complete_with_context(Some("MyCtrl"), None, &[])
+        .expect("controller prefix で補完応答が返るべき");
+    let labels: Vec<String> = match resp {
+        CompletionResponse::Array(items) => items.into_iter().map(|i| i.label).collect(),
+        _ => panic!("Array response 期待"),
+    };
+
+    assert!(
+        labels.iter().any(|l| l == "refresh"),
+        "this.refresh は controller プレフィックス補完に含まれるべき (labels: {:?})",
+        labels
+    );
+    assert!(
+        !labels.iter().any(|l| l.starts_with("$scope.")),
+        "$scope.X は controller プレフィックス補完に混入してはいけない (labels: {:?})",
+        labels
+    );
+}
+
+#[test]
+fn test_html_completion_does_not_duplicate_scope_method_with_dollar_scope_label() {
+    // HTML 内の {{ }} 補完で `$scope.update = function() {}` を定義した場合、
+    // `update` (Function) のみが候補に出るべきで、`$scope.update` (Method) が
+    // 並んで出てはいけない。
+    use angularjs_lsp::handler::CompletionHandler;
+
+    let js = r#"
+angular.module('app', []).controller('MyCtrl', ['$scope', function($scope) {
+    $scope.update = function() {};
+}]);
+"#;
+    let html = r#"<div ng-controller="MyCtrl">{{ }}</div>"#;
+    let index = analyze_html(js, html);
+    let handler = CompletionHandler::new(index);
+    let html_uri = Url::parse("file:///test.html").unwrap();
+
+    let items = handler.complete_in_html_angular_context(&html_uri, 0);
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+
+    assert!(
+        labels.contains(&"update"),
+        "HTML 補完に 'update' が含まれるべき (labels: {:?})",
+        labels
+    );
+    assert!(
+        !labels.contains(&"$scope.update"),
+        "HTML 補完に '$scope.update' という重複候補が含まれてはいけない (labels: {:?})",
+        labels
+    );
+}


### PR DESCRIPTION
## Summary

- `$scope.foo = function() {}` を定義したとき、HTML 内の `{{ }}` 補完候補に `foo` (Function) と `$scope.foo` (Method) の 2 件が並んで出ていた問題を修正
- 原因は `complete_with_context` の controller プレフィックス分岐で kind フィルタが無く、`MyCtrl.$scope.foo` のような ScopeMethod シンボルもプレフィックス一致で拾われていたため
- リグレッションテスト 2 件追加

## なぜ起きていたか

シンボルストアには `MyCtrl.$scope.update` (kind = `ScopeMethod`) が **1 件だけ** 登録されている (解析時の重複登録は無し)。一方、`complete_in_html_angular_context` は controller ごとに 2 つの補完分岐を呼ぶ:

1. `complete_with_context(Some("\$scope"), Some("MyCtrl"), ...)` → `update` (Function) を出す ← 正しい
2. `complete_with_context(Some("MyCtrl"), None, ...)` → `this.X` メソッドを出すための分岐

問題は ② の filter:

```rust
let method_prefix = format!("{}.", prefix);  // "MyCtrl."
definitions.into_iter()
    .filter(|s| s.name.starts_with(&method_prefix))
```

`MyCtrl.$scope.update` も `"MyCtrl."` で始まるためマッチしてしまい、`strip_prefix("MyCtrl.")` → `"\$scope.update"` がそのまま label になって `METHOD` として emit されていた。

## 修正

② の分岐で `ScopeProperty` / `ScopeMethod` / `RootScopeProperty` / `RootScopeMethod` を kind 単位で除外。これらは ① の分岐 (および `$rootScope` 分岐) で扱うべき候補のため、controller/service プレフィックス分岐ではそもそも返さない。

```rust
.filter(|s| {
    s.name.starts_with(&method_prefix)
        && !matches!(
            s.kind,
            SymbolKind::ScopeProperty | SymbolKind::ScopeMethod
            | SymbolKind::RootScopeProperty | SymbolKind::RootScopeMethod
        )
})
```

## 変更ファイル

- `src/handler/completion.rs` — kind フィルタ追加 + 経緯のコメント
- `tests/angularjs_common_syntax_test.rs` — 回帰テスト 2 件

## Test plan

- [x] `cargo test` フルスイート (115 + 79 + 79 + 2 件) すべて pass
- [x] 新規テスト `test_controller_prefix_completion_excludes_scope_methods` — controller プレフィックス補完に `\$scope.X` ラベルが混入しないこと
- [x] 新規テスト `test_html_completion_does_not_duplicate_scope_method_with_dollar_scope_label` — HTML `{{ }}` 補完に `update` のみ出て `\$scope.update` は出ないこと
- [ ] エディタ実機で `\$scope.foo = function() {}` を定義した HTML テンプレート内で補完を呼び、`foo` のみが出ることを目視確認 (任意)

🤖 Generated with [Claude Code](https://claude.com/claude-code)