### PR TITLE
perf: シンボル参照アクセスを borrowing API に置換し Vec clone を回避

### DIFF
--- a/src/handler/diagnostics.rs
+++ b/src/handler/diagnostics.rs
@@ -91,8 +91,11 @@ impl DiagnosticsHandler {
                 self.index.is_scope_variable_referenced(&symbol.name);
 
             // 他のJSファイル（他のコントローラー）からの参照があるかチェック
-            let js_refs = self.index.definitions.get_references(&symbol.name);
-            let is_referenced_in_other_js = js_refs.iter().any(|r| r.uri != *uri);
+            // any_reference で短絡評価し、Vec 全件 clone を回避
+            let is_referenced_in_other_js = self
+                .index
+                .definitions
+                .any_reference(&symbol.name, |r| r.uri != *uri);
 
             debug!(
                 "check_unused_scope_variables: symbol='{}', property='{}', html_ref={}, other_js_ref={}",
@@ -105,7 +108,10 @@ impl DiagnosticsHandler {
             }
 
             // 同一ファイル内での参照があるかチェック
-            let is_referenced_in_same_js = js_refs.iter().any(|r| r.uri == *uri);
+            let is_referenced_in_same_js = self
+                .index
+                .definitions
+                .any_reference(&symbol.name, |r| r.uri == *uri);
 
             // 警告メッセージを分岐: 完全に未参照か、同一ファイル内でのみ参照されているか
             let message = if is_referenced_in_same_js {

--- a/src/index/definition_store.rs
+++ b/src/index/definition_store.rs
@@ -82,6 +82,33 @@ impl DefinitionStore {
             .unwrap_or_default()
     }
 
+    /// 指定シンボル名の参照を借用イテレートする (Vec 全件 clone を回避)
+    ///
+    /// 注意: 内部で DashMap shard の read lock を保持するため、`f` 内で同じ
+    /// `DefinitionStore` を変更するメソッド (add_reference / clear_document など)
+    /// を呼ばないこと。デッドロックする可能性がある。
+    pub fn for_each_reference<F: FnMut(&SymbolReference)>(&self, name: &str, mut f: F) {
+        if let Some(refs) = self.references.get(name) {
+            for r in refs.value().iter() {
+                f(r);
+            }
+        }
+    }
+
+    /// 指定シンボル名の参照のうち述語にマッチするものがあるか (短絡評価)
+    ///
+    /// 注意: `for_each_reference` と同じくデッドロック注意。
+    pub fn any_reference<F: FnMut(&SymbolReference) -> bool>(&self, name: &str, mut f: F) -> bool {
+        if let Some(refs) = self.references.get(name) {
+            for r in refs.value().iter() {
+                if f(r) {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
     pub fn get_all_definitions(&self) -> Vec<Symbol> {
         self.definitions
             .iter()
@@ -483,5 +510,91 @@ mod tests {
 
         // 一方で definitions 側には 2 件残っている
         assert_eq!(store.get_definitions("Ctrl.$scope.x").len(), 2);
+    }
+
+    #[test]
+    fn for_each_reference_visits_all_refs() {
+        let store = DefinitionStore::new();
+        let uri_a = Url::parse("file:///a.js").unwrap();
+        let uri_b = Url::parse("file:///b.js").unwrap();
+
+        store.add_reference(make_reference("Ctrl.$scope.x", &uri_a));
+        store.add_reference(SymbolReference {
+            name: "Ctrl.$scope.x".to_string(),
+            uri: uri_b.clone(),
+            span: Span::new(1, 0, 1, 1),
+        });
+
+        let mut visited: Vec<Url> = Vec::new();
+        store.for_each_reference("Ctrl.$scope.x", |r| {
+            visited.push(r.uri.clone());
+        });
+        visited.sort();
+        let mut expected = vec![uri_a, uri_b];
+        expected.sort();
+        assert_eq!(visited, expected);
+    }
+
+    #[test]
+    fn for_each_reference_does_nothing_for_unknown_name() {
+        let store = DefinitionStore::new();
+        let mut count = 0;
+        store.for_each_reference("does.not.exist", |_| count += 1);
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn any_reference_returns_true_when_predicate_matches() {
+        let store = DefinitionStore::new();
+        let uri_a = Url::parse("file:///a.js").unwrap();
+        let uri_b = Url::parse("file:///b.js").unwrap();
+
+        store.add_reference(make_reference("Ctrl.$scope.x", &uri_a));
+        store.add_reference(SymbolReference {
+            name: "Ctrl.$scope.x".to_string(),
+            uri: uri_b.clone(),
+            span: Span::new(1, 0, 1, 1),
+        });
+
+        assert!(store.any_reference("Ctrl.$scope.x", |r| r.uri == uri_b));
+    }
+
+    #[test]
+    fn any_reference_returns_false_when_no_match() {
+        let store = DefinitionStore::new();
+        let uri_a = Url::parse("file:///a.js").unwrap();
+        let uri_other = Url::parse("file:///other.js").unwrap();
+
+        store.add_reference(make_reference("Ctrl.$scope.x", &uri_a));
+        assert!(!store.any_reference("Ctrl.$scope.x", |r| r.uri == uri_other));
+    }
+
+    #[test]
+    fn any_reference_short_circuits_on_first_match() {
+        // 述語が複数件にマッチし得る状況で、最初の一致で停止していること
+        let store = DefinitionStore::new();
+        let uri = make_uri();
+
+        for line in 0..5u32 {
+            store.add_reference(SymbolReference {
+                name: "Ctrl.$scope.x".to_string(),
+                uri: uri.clone(),
+                span: Span::new(line, 0, line, 1),
+            });
+        }
+
+        let mut visits = 0;
+        let result = store.any_reference("Ctrl.$scope.x", |_| {
+            visits += 1;
+            true
+        });
+        assert!(result);
+        assert_eq!(visits, 1, "述語が true を返した時点で停止すべき");
+    }
+
+    #[test]
+    fn any_reference_returns_false_for_unknown_name() {
+        let store = DefinitionStore::new();
+        assert!(!store.any_reference("does.not.exist", |_| true));
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -186,13 +186,14 @@ fn collect_affected_html_uris(
     let mut affected: HashSet<Url> = HashSet::new();
 
     // 1. シンボル名参照を持つ HTML
+    //    全件 Vec clone を避けるため for_each_reference で借用イテレート
     let candidate_names: HashSet<&String> = before_symbols.union(after_symbols).collect();
     for name in candidate_names {
-        for reference in index.definitions.get_references(name) {
+        index.definitions.for_each_reference(name, |reference| {
             if is_html_file(&reference.uri) && documents.contains_key(&reference.uri) {
-                affected.insert(reference.uri);
+                affected.insert(reference.uri.clone());
             }
-        }
+        });
     }
 
     // 2. この JS で宣言されている template binding のテンプレート


### PR DESCRIPTION
## Summary

- `DefinitionStore::get_references` の Vec 全件 clone がホットパスで無駄になっていた問題を、借用ベースの `for_each_reference` / `any_reference` で置換
- 2 箇所のホットパス (HTML 影響範囲計算 / JS 診断の早期判定) を更新

## 背景

`DefinitionStore::get_references(name)` は `Vec<SymbolReference>::clone()` を返すため、フィルタで捨てる予定の参照や、`.any(...)` で短絡できる判定でも先に全件 clone してから処理してしまっていた。

特に問題だったのは:

### 1. `collect_affected_html_uris` (`src/server/mod.rs`)
```rust
for name in candidate_names {
    for reference in index.definitions.get_references(name) {
        if is_html_file(&reference.uri) && documents.contains_key(&reference.uri) {
            affected.insert(reference.uri);
        }
    }
}
```
- `MyCtrl` のような controller シンボルは workspace 全体で多数参照され得るが、開いてる HTML 数件のために全件 clone → 99% 捨て
- JS 編集 1 回で `O(候補名数 × 全リファレンス数)` の clone

### 2. `check_unused_scope_variables` (`src/handler/diagnostics.rs`)
```rust
let js_refs = self.index.definitions.get_references(&symbol.name);
let is_referenced_in_other_js = js_refs.iter().any(|r| r.uri != *uri);
\`\`\`
- JS 診断のたびに scope 定義数だけ呼ばれる (より高頻度)
- `.any` で短絡できるはずなのに全件 clone してから判定するのが二重に無駄
- 直後の \`is_referenced_in_same_js\` も同じ \`js_refs\` を再利用しているが、同様に短絡判定で良い

その他の \`get_references\` 呼出 (\`query.rs\`, \`references.rs\`, \`rename.rs\`, \`cache/writer.rs\`) は結果を返却・全消費する用途なので clone のまま妥当。

## 変更内容

### \`src/index/definition_store.rs\`
- \`for_each_reference(name, F: FnMut(&SymbolReference))\`: 借用イテレート (Vec clone なし)
- \`any_reference(name, F: FnMut(&SymbolReference) -> bool) -> bool\`: 短絡評価
- 既存 \`get_references\` は維持 (LSP/cache の全件返却用)
- DashMap shard read lock を callback 中保持する旨の注意コメントを追加

### \`src/server/mod.rs\`
- \`collect_affected_html_uris\` の参照ルックアップを \`for_each_reference\` に置換
- 必要な \`Url::clone\` のみ残る

### \`src/handler/diagnostics.rs\`
- \`check_unused_scope_variables\` の \`is_referenced_in_other_js\` / \`is_referenced_in_same_js\` を \`any_reference\` に置換
- \`get_references\` 呼出を完全削除

### テスト
\`definition_store.rs\` の \`tests\` モジュールに 5 テスト追加:
- 全件訪問
- 未知名で no-op
- 述語マッチで true
- マッチなしで false
- 早期 break (述語が true 時点で停止)
- 未知名で false

## Test plan

- [x] \`cargo test\` 全件 pass (lib 95 / 統合 115 + 2)
- [x] \`cargo clippy\` 変更ファイルに新規警告なし
- [x] PR #27 の絞り込みと組み合わせて動作 (PR #27 マージ後の master をベースとしている)
- [ ] (人手) 大量 HTML/JS が開かれた状態で JS 編集 → CPU プロファイリングで clone 削減を確認

## 採用しなかった案

\`references_by_uri: DashMap<Url, Vec<SymbolReference>>\` の逆引きインデックス追加は見送った。借用 API で十分軽量化でき、二重持ちのメンテコスト・一貫性リスクを避けるため。

🤖 Generated with [Claude Code](https://claude.com/claude-code)