### PR TITLE
feat: interpolate 記号を AngularJS ソース ($interpolateProvider) から解決する

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "tokio",
  "tower-lsp",
@@ -31,6 +32,12 @@ dependencies = [
  "tree-sitter-html",
  "tree-sitter-javascript",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "async-trait"
@@ -168,10 +175,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645cbb3a84e60b7531617d5ae4e57f7e27308f6445f5abf653209ea76dec8dff"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -266,6 +285,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,9 +324,24 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "httparse"
@@ -384,6 +431,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +465,8 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -427,10 +482,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.179"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a2d376baa530d1238d133232d15e239abad80d05838b4b59354e5268af431f"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -620,6 +687,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -645,6 +722,12 @@ checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -742,6 +825,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.10.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -895,6 +991,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1174,6 +1283,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1203,6 +1318,58 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.10.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
 
 [[package]]
 name = "windows-link"
@@ -1300,6 +1467,100 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.10.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ phf = { version = "0.11", features = ["macros"] }
 
 [dev-dependencies]
 rstest = "0.24"
+tempfile = "3"
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -155,10 +155,6 @@ Create an `ajsconfig.json` file in your project root to customize the language s
 {
   "include": ["src/**/*.js", "app/**/*.js"],
   "exclude": ["**/test/**", "**/vendor/**"],
-  "interpolate": {
-    "startSymbol": "{{",
-    "endSymbol": "}}"
-  },
   "cache": true,
   "diagnostics": {
     "enabled": true,
@@ -167,14 +163,17 @@ Create an `ajsconfig.json` file in your project root to customize the language s
 }
 ```
 
+> **Note**: Interpolation delimiters (`{{` / `}}`) are **not** configured here.
+> The language server detects them from `$interpolateProvider.startSymbol(...)` /
+> `.endSymbol(...)` calls in your AngularJS source. See
+> [Interpolation symbols](#interpolation-symbols) for details.
+
 ### Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `include` | `string[]` | `[]` (all files) | Glob patterns for files to analyze. If empty, all files are included. |
 | `exclude` | `string[]` | (see below) | Glob patterns for files/directories to exclude. |
-| `interpolate.startSymbol` | `string` | `{{` | AngularJS interpolation start symbol. **Fallback only**: the language server first detects the symbols from `$interpolateProvider.startSymbol(...)` calls in your JS source. This config is consulted only when no such call is found. See [Interpolation symbol resolution](#interpolation-symbol-resolution). |
-| `interpolate.endSymbol` | `string` | `}}` | AngularJS interpolation end symbol. **Fallback only** (same as above). |
 | `cache` | `boolean` | `true` | Enable caching of parsed symbols. Cache is stored in `.angularjs-lsp/cache/`. |
 | `diagnostics.enabled` | `boolean` | `true` | Enable diagnostics for undefined scope properties and local variables. |
 | `diagnostics.severity` | `string` | `"warning"` | Severity level: `"error"`, `"warning"`, `"hint"`, or `"information"`. |
@@ -204,55 +203,29 @@ By default, the following patterns are excluded:
 }
 ```
 
-### Interpolation symbol resolution
+### Interpolation symbols
 
-The language server resolves the interpolation delimiters in this order:
+The language server resolves AngularJS interpolation delimiters from your JS source by
+detecting `$interpolateProvider.startSymbol(...)` / `.endSymbol(...)` calls.
+This matches AngularJS's actual runtime behavior, so there is no separate LSP config to keep in sync.
 
-1. **`$interpolateProvider.startSymbol(...)` / `.endSymbol(...)` calls in your JS source** (preferred).
-   This matches AngularJS's actual runtime behavior, so you don't need to keep an LSP-specific config in sync with your code.
+```js
+angular.module('app', [])
+  .config(['$interpolateProvider', function($interpolateProvider) {
+    $interpolateProvider.startSymbol('[[');
+    $interpolateProvider.endSymbol(']]');
+  }]);
+```
 
-   ```js
-   angular.module('app', [])
-     .config(['$interpolateProvider', function($interpolateProvider) {
-       $interpolateProvider.startSymbol('[[');
-       $interpolateProvider.endSymbol(']]');
-     }]);
-   ```
+The following invocation patterns are all recognized:
 
-   Implicit DI (`function($interpolateProvider) { ... }`), array-DI rename
-   (`['$interpolateProvider', function(ip) { ip.startSymbol('[[') }]`), and chained calls
-   (`.startSymbol('[[').endSymbol(']]')`) are all detected.
-
-2. **`ajsconfig.json`'s `interpolate.startSymbol` / `interpolate.endSymbol`** (fallback).
-   Useful when your project sets symbols outside JS (e.g., via build-time replacement)
-   or when you only want to override the LSP's perception without touching code.
-
-3. **AngularJS default `{{` / `}}`** (final fallback).
+- Implicit DI: `function($interpolateProvider) { $interpolateProvider.startSymbol('[[') }`
+- Array-style DI with rename: `['$interpolateProvider', function(ip) { ip.startSymbol('[[') }]`
+- Chained calls: `.startSymbol('[[').endSymbol(']]')`
 
 `start` and `end` are resolved independently, so projects that customize only one side
 (e.g., `startSymbol('[[')` while keeping `}}` as the end) still work correctly.
-
-**Custom interpolation symbols (e.g., for ERB/Jinja compatibility):**
-
-The recommended approach is to set them in your AngularJS source (the LSP picks them up automatically):
-
-```js
-angular.module('app', []).config(['$interpolateProvider', function($interpolateProvider) {
-  $interpolateProvider.startSymbol('[[');
-  $interpolateProvider.endSymbol(']]');
-}]);
-```
-
-If you cannot or prefer not to touch the JS, fall back to `ajsconfig.json`:
-
-```json
-{
-  "interpolate": {
-    "startSymbol": "[[",
-    "endSymbol": "]]"
-  }
-}
-```
+If neither call is found, the AngularJS default `{{` / `}}` is used.
 
 **Disable diagnostics or change severity:**
 ```json

--- a/README.md
+++ b/README.md
@@ -163,11 +163,6 @@ Create an `ajsconfig.json` file in your project root to customize the language s
 }
 ```
 
-> **Note**: Interpolation delimiters (`{{` / `}}`) are **not** configured here.
-> The language server detects them from `$interpolateProvider.startSymbol(...)` /
-> `.endSymbol(...)` calls in your AngularJS source. See
-> [Interpolation symbols](#interpolation-symbols) for details.
-
 ### Options
 
 | Option | Type | Default | Description |
@@ -202,30 +197,6 @@ By default, the following patterns are excluded:
   "exclude": ["**/test/**", "**/spec/**", "**/*.spec.js", "**/*.test.js"]
 }
 ```
-
-### Interpolation symbols
-
-The language server resolves AngularJS interpolation delimiters from your JS source by
-detecting `$interpolateProvider.startSymbol(...)` / `.endSymbol(...)` calls.
-This matches AngularJS's actual runtime behavior, so there is no separate LSP config to keep in sync.
-
-```js
-angular.module('app', [])
-  .config(['$interpolateProvider', function($interpolateProvider) {
-    $interpolateProvider.startSymbol('[[');
-    $interpolateProvider.endSymbol(']]');
-  }]);
-```
-
-The following invocation patterns are all recognized:
-
-- Implicit DI: `function($interpolateProvider) { $interpolateProvider.startSymbol('[[') }`
-- Array-style DI with rename: `['$interpolateProvider', function(ip) { ip.startSymbol('[[') }]`
-- Chained calls: `.startSymbol('[[').endSymbol(']]')`
-
-`start` and `end` are resolved independently, so projects that customize only one side
-(e.g., `startSymbol('[[')` while keeping `}}` as the end) still work correctly.
-If neither call is found, the AngularJS default `{{` / `}}` is used.
 
 **Disable diagnostics or change severity:**
 ```json

--- a/README.md
+++ b/README.md
@@ -173,8 +173,8 @@ Create an `ajsconfig.json` file in your project root to customize the language s
 |--------|------|---------|-------------|
 | `include` | `string[]` | `[]` (all files) | Glob patterns for files to analyze. If empty, all files are included. |
 | `exclude` | `string[]` | (see below) | Glob patterns for files/directories to exclude. |
-| `interpolate.startSymbol` | `string` | `{{` | AngularJS interpolation start symbol. |
-| `interpolate.endSymbol` | `string` | `}}` | AngularJS interpolation end symbol. |
+| `interpolate.startSymbol` | `string` | `{{` | AngularJS interpolation start symbol. **Fallback only**: the language server first detects the symbols from `$interpolateProvider.startSymbol(...)` calls in your JS source. This config is consulted only when no such call is found. See [Interpolation symbol resolution](#interpolation-symbol-resolution). |
+| `interpolate.endSymbol` | `string` | `}}` | AngularJS interpolation end symbol. **Fallback only** (same as above). |
 | `cache` | `boolean` | `true` | Enable caching of parsed symbols. Cache is stored in `.angularjs-lsp/cache/`. |
 | `diagnostics.enabled` | `boolean` | `true` | Enable diagnostics for undefined scope properties and local variables. |
 | `diagnostics.severity` | `string` | `"warning"` | Severity level: `"error"`, `"warning"`, `"hint"`, or `"information"`. |
@@ -204,7 +204,47 @@ By default, the following patterns are excluded:
 }
 ```
 
+### Interpolation symbol resolution
+
+The language server resolves the interpolation delimiters in this order:
+
+1. **`$interpolateProvider.startSymbol(...)` / `.endSymbol(...)` calls in your JS source** (preferred).
+   This matches AngularJS's actual runtime behavior, so you don't need to keep an LSP-specific config in sync with your code.
+
+   ```js
+   angular.module('app', [])
+     .config(['$interpolateProvider', function($interpolateProvider) {
+       $interpolateProvider.startSymbol('[[');
+       $interpolateProvider.endSymbol(']]');
+     }]);
+   ```
+
+   Implicit DI (`function($interpolateProvider) { ... }`), array-DI rename
+   (`['$interpolateProvider', function(ip) { ip.startSymbol('[[') }]`), and chained calls
+   (`.startSymbol('[[').endSymbol(']]')`) are all detected.
+
+2. **`ajsconfig.json`'s `interpolate.startSymbol` / `interpolate.endSymbol`** (fallback).
+   Useful when your project sets symbols outside JS (e.g., via build-time replacement)
+   or when you only want to override the LSP's perception without touching code.
+
+3. **AngularJS default `{{` / `}}`** (final fallback).
+
+`start` and `end` are resolved independently, so projects that customize only one side
+(e.g., `startSymbol('[[')` while keeping `}}` as the end) still work correctly.
+
 **Custom interpolation symbols (e.g., for ERB/Jinja compatibility):**
+
+The recommended approach is to set them in your AngularJS source (the LSP picks them up automatically):
+
+```js
+angular.module('app', []).config(['$interpolateProvider', function($interpolateProvider) {
+  $interpolateProvider.startSymbol('[[');
+  $interpolateProvider.endSymbol(']]');
+}]);
+```
+
+If you cannot or prefer not to touch the JS, fall back to `ajsconfig.json`:
+
 ```json
 {
   "interpolate": {

--- a/src/analyzer/html/mod.rs
+++ b/src/analyzer/html/mod.rs
@@ -1,11 +1,10 @@
 //! HTML内のAngularJSディレクティブを解析するモジュール
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use tower_lsp::lsp_types::Url;
 use tree_sitter::{Node, Tree};
 
-use crate::config::InterpolateConfig;
 use crate::index::Index;
 
 pub mod controller;
@@ -27,7 +26,6 @@ pub use script::EmbeddedScript;
 pub struct HtmlAngularJsAnalyzer {
     index: Arc<Index>,
     js_analyzer: Arc<crate::analyzer::js::AngularJsAnalyzer>,
-    interpolate: RwLock<InterpolateConfig>,
 }
 
 impl HtmlAngularJsAnalyzer {
@@ -35,24 +33,17 @@ impl HtmlAngularJsAnalyzer {
         Self {
             index,
             js_analyzer,
-            interpolate: RwLock::new(InterpolateConfig::default()),
         }
     }
 
-    /// interpolate設定を更新
-    pub fn set_interpolate_config(&self, config: InterpolateConfig) {
-        if let Ok(mut interpolate) = self.interpolate.write() {
-            *interpolate = config;
-        }
-    }
-
-    /// 現在のinterpolate設定を取得
+    /// 現在のinterpolate記号を取得する。
+    ///
+    /// 解決順は `Index::interpolate.resolved()` に委譲:
+    /// 1. JS の `$interpolateProvider.startSymbol(...)` / `.endSymbol(...)` で検出された値
+    /// 2. `ajsconfig.json` の `interpolate` (フォールバック)
+    /// 3. AngularJS デフォルト `{{` / `}}`
     pub(self) fn get_interpolate_symbols(&self) -> (String, String) {
-        if let Ok(config) = self.interpolate.read() {
-            (config.start_symbol.clone(), config.end_symbol.clone())
-        } else {
-            ("{{".to_string(), "}}".to_string())
-        }
+        self.index.interpolate.resolved()
     }
 
     /// HTMLドキュメントを解析（単独ファイル解析用）

--- a/src/analyzer/js/component.rs
+++ b/src/analyzer/js/component.rs
@@ -66,6 +66,19 @@ impl AngularJsAnalyzer {
                                 self.extract_route_when_di(node, source, uri, ctx);
                             }
                         }
+                        "startSymbol" | "endSymbol" => {
+                            // `$interpolateProvider.startSymbol('[[')` のような呼び出しから
+                            // interpolate 記号をワークスペース全体の設定として収集する。
+                            // ajsconfig.json 設定よりも優先される (詳細は InterpolateStore)
+                            if self.is_provider_receiver(callee, source, ctx, "interpolateProvider") {
+                                self.extract_interpolate_symbol_call(
+                                    node,
+                                    source,
+                                    uri,
+                                    method_name.as_str(),
+                                );
+                            }
+                        }
                         "state" => {
                             // 同上、`$stateProvider` (ui-router) 限定
                             if self.is_provider_receiver(callee, source, ctx, "stateProvider") {
@@ -76,6 +89,36 @@ impl AngularJsAnalyzer {
                     }
                 }
             }
+        }
+    }
+
+    /// `$interpolateProvider.startSymbol('[[')` / `.endSymbol(']]')` の呼び出しから
+    /// interpolate 記号を抽出して `Index::interpolate` に登録する。
+    ///
+    /// 文字列リテラル以外 (動的式) は無視する。
+    pub(super) fn extract_interpolate_symbol_call(
+        &self,
+        node: Node,
+        source: &str,
+        uri: &Url,
+        method: &str,
+    ) {
+        let args = match node.child_by_field_name("arguments") {
+            Some(a) => a,
+            None => return,
+        };
+        let first_arg = match args.named_child(0) {
+            Some(a) => a,
+            None => return,
+        };
+        if first_arg.kind() != "string" {
+            return;
+        }
+        let value = self.extract_string_value(first_arg, source);
+        match method {
+            "startSymbol" => self.index.interpolate.set_start_symbol(uri.clone(), value),
+            "endSymbol" => self.index.interpolate.set_end_symbol(uri.clone(), value),
+            _ => {}
         }
     }
 

--- a/src/analyzer/js/tests/mod.rs
+++ b/src/analyzer/js/tests/mod.rs
@@ -660,6 +660,162 @@ angular.module('app', [])
     );
 }
 
+// ==========================================================================
+// `$interpolateProvider.startSymbol/endSymbol` 検出
+// ==========================================================================
+
+#[test]
+fn test_interpolate_provider_start_and_end_symbols() {
+    // 配列 DI で $interpolateProvider を受け取って startSymbol/endSymbol 設定
+    let index = analyze(
+        r#"
+angular.module('app', [])
+.config(['$interpolateProvider', function($interpolateProvider) {
+    $interpolateProvider.startSymbol('[[');
+    $interpolateProvider.endSymbol(']]');
+}]);
+"#,
+    );
+
+    assert_eq!(
+        index.interpolate.resolved(),
+        ("[[".to_string(), "]]".to_string())
+    );
+}
+
+#[test]
+fn test_interpolate_provider_renamed_via_array_di() {
+    // 配列 DI で `ip` にリネーム → DI 経由で receiver 解決される
+    let index = analyze(
+        r#"
+angular.module('app', [])
+.config(['$interpolateProvider', function(ip) {
+    ip.startSymbol('<%');
+    ip.endSymbol('%>');
+}]);
+"#,
+    );
+
+    assert_eq!(
+        index.interpolate.resolved(),
+        ("<%".to_string(), "%>".to_string())
+    );
+}
+
+#[test]
+fn test_interpolate_provider_implicit_di() {
+    // 暗黙 DI 形式
+    let index = analyze(
+        r#"
+angular.module('app', [])
+.config(function($interpolateProvider) {
+    $interpolateProvider.startSymbol('{<');
+    $interpolateProvider.endSymbol('>}');
+});
+"#,
+    );
+
+    assert_eq!(
+        index.interpolate.resolved(),
+        ("{<".to_string(), ">}".to_string())
+    );
+}
+
+#[test]
+fn test_interpolate_provider_dynamic_argument_ignored() {
+    // 動的引数 (変数参照) は無視 (静的解析できない)
+    let index = analyze(
+        r#"
+var s = '[[';
+angular.module('app', [])
+.config(['$interpolateProvider', function($interpolateProvider) {
+    $interpolateProvider.startSymbol(s);
+}]);
+"#,
+    );
+
+    // start は default のまま
+    assert_eq!(index.interpolate.resolved().0, "{{".to_string());
+}
+
+#[test]
+fn test_interpolate_provider_unrelated_object_ignored() {
+    // $interpolateProvider 以外のオブジェクトの startSymbol は無視
+    let index = analyze(
+        r#"
+var random = {};
+random.startSymbol('[[');
+random.endSymbol(']]');
+"#,
+    );
+
+    // デフォルトのまま
+    assert_eq!(
+        index.interpolate.resolved(),
+        ("{{".to_string(), "}}".to_string())
+    );
+}
+
+#[test]
+fn test_interpolate_provider_only_start_symbol_set() {
+    // startSymbol だけ JS 検出、endSymbol はフォールバック側
+    let index = analyze(
+        r#"
+angular.module('app', [])
+.config(['$interpolateProvider', function($interpolateProvider) {
+    $interpolateProvider.startSymbol('[[');
+}]);
+"#,
+    );
+
+    assert_eq!(index.interpolate.resolved().0, "[[".to_string());
+    assert_eq!(index.interpolate.resolved().1, "}}".to_string());
+}
+
+#[test]
+fn test_interpolate_provider_chained_calls() {
+    // チェイン呼び出し
+    let index = analyze(
+        r#"
+angular.module('app', [])
+.config(['$interpolateProvider', function($interpolateProvider) {
+    $interpolateProvider
+        .startSymbol('{|')
+        .endSymbol('|}');
+}]);
+"#,
+    );
+
+    assert_eq!(
+        index.interpolate.resolved(),
+        ("{|".to_string(), "|}".to_string())
+    );
+}
+
+#[test]
+fn test_interpolate_provider_clear_document_resets() {
+    // 該当 JS を re-analyze する状況: 一度設定後、別の解析でクリアされる
+    let index = analyze(
+        r#"
+angular.module('app', [])
+.config(['$interpolateProvider', function($interpolateProvider) {
+    $interpolateProvider.startSymbol('[[');
+    $interpolateProvider.endSymbol(']]');
+}]);
+"#,
+    );
+
+    assert_eq!(index.interpolate.resolved().0, "[[".to_string());
+
+    // re-analyze (空の) 状態で同 URI が startSymbol を含まなくなる → デフォルトに戻る
+    let analyzer = AngularJsAnalyzer::new(Arc::clone(&index));
+    analyzer.analyze_document(&test_uri(), "// nothing here\n");
+    assert_eq!(
+        index.interpolate.resolved(),
+        ("{{".to_string(), "}}".to_string())
+    );
+}
+
 #[test]
 fn test_chain_receiver_unrelated_origin_is_not_route() {
     // チェインの根が $routeProvider と無関係のオブジェクトなら、

--- a/src/cache/loader.rs
+++ b/src/cache/loader.rs
@@ -188,7 +188,18 @@ impl CacheLoader {
             index.templates.add_ng_include_binding_with_key(key, binding);
         }
 
-        info!("Loaded global data from cache");
+        let mut restored_interpolate = 0;
+        for (uri_str, start, end) in global_data.interpolate_symbols {
+            if let Ok(uri) = Url::parse(&uri_str) {
+                index.interpolate.restore_from_cache(uri, start, end);
+                restored_interpolate += 1;
+            }
+        }
+
+        info!(
+            "Loaded global data from cache ({} interpolate entries)",
+            restored_interpolate
+        );
         Ok(())
     }
 }

--- a/src/cache/metadata.rs
+++ b/src/cache/metadata.rs
@@ -3,7 +3,8 @@ use std::collections::HashMap;
 
 /// Cache format version
 /// v2: HTML cache support
-pub const CACHE_VERSION: u32 = 2;
+/// v3: `$interpolateProvider` 検出値の永続化 (CachedGlobalData.interpolate_symbols 追加)
+pub const CACHE_VERSION: u32 = 3;
 
 /// Cache metadata
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/cache/schema.rs
+++ b/src/cache/schema.rs
@@ -32,4 +32,13 @@ pub struct CachedSymbolData {
 pub struct CachedGlobalData {
     pub template_bindings: Vec<TemplateBinding>,
     pub ng_include_bindings: Vec<(String, NgIncludeBinding)>,
+    /// JS から検出された `$interpolateProvider.startSymbol/endSymbol` の値を
+    /// URI 単位で永続化する。`(uri_str, start_symbol, end_symbol)` の Vec。
+    /// 各 URI で start/end どちらか片方だけ宣言されているケースもあり得るので
+    /// それぞれ Option で保持する。
+    ///
+    /// このフィールドが無いとキャッシュからの起動時に `InterpolateStore` が
+    /// 空になり、custom interpolate 記号を使うプロジェクトで HTML 解析が
+    /// デフォルト `{{ }}` で動いてしまう。
+    pub interpolate_symbols: Vec<(String, Option<String>, Option<String>)>,
 }

--- a/src/cache/writer.rs
+++ b/src/cache/writer.rs
@@ -178,9 +178,18 @@ impl CacheWriter {
     }
 
     fn save_global_data(&self, index: &Index) -> Result<(), Box<dyn std::error::Error>> {
+        // InterpolateStore の JS 検出値を URI string 化して保存
+        let interpolate_symbols: Vec<(String, Option<String>, Option<String>)> = index
+            .interpolate
+            .iter_js_detected_for_cache()
+            .into_iter()
+            .map(|(uri, start, end)| (uri.to_string(), start, end))
+            .collect();
+
         let global_data = CachedGlobalData {
             template_bindings: index.templates.get_all_template_bindings(),
             ng_include_bindings: index.templates.get_all_ng_include_bindings(),
+            interpolate_symbols,
         };
 
         let data = bincode::serialize(&global_data)?;
@@ -188,11 +197,94 @@ impl CacheWriter {
         fs::write(&global_path, data)?;
 
         debug!(
-            "Saved global cache: {} template_bindings, {} ng_include_bindings",
+            "Saved global cache: {} template_bindings, {} ng_include_bindings, {} interpolate_symbols",
             global_data.template_bindings.len(),
-            global_data.ng_include_bindings.len()
+            global_data.ng_include_bindings.len(),
+            global_data.interpolate_symbols.len()
         );
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+    use tempfile::TempDir;
+    use tower_lsp::lsp_types::Url;
+
+    use crate::cache::loader::CacheLoader;
+
+    /// `$interpolateProvider` 検出値を save → load で復元できることを確認。
+    /// これがないとカスタム interpolate 記号を使うプロジェクトで cache hit 起動時に
+    /// HTML 解析がデフォルト `{{ }}` で動いてしまう。
+    #[test]
+    fn interpolate_symbols_round_trip() {
+        let tmp = TempDir::new().unwrap();
+        let workspace_root = tmp.path();
+
+        // 元 Index に interpolate 検出値を入れる
+        let original = Index::new();
+        let uri_a = Url::parse("file:///a.js").unwrap();
+        let uri_b = Url::parse("file:///b.js").unwrap();
+        original
+            .interpolate
+            .set_start_symbol(uri_a.clone(), "<%".to_string());
+        original
+            .interpolate
+            .set_end_symbol(uri_a.clone(), "%>".to_string());
+        original
+            .interpolate
+            .set_start_symbol(uri_b.clone(), "[[".to_string());
+        // uri_b は end_symbol を宣言していない (片方だけのケース)
+
+        // 書き出し
+        let writer = CacheWriter::new(workspace_root);
+        let metadata = HashMap::new();
+        writer.save_full(&original, &metadata).unwrap();
+
+        // 別 Index にロード
+        let restored = Index::new();
+        let loader = CacheLoader::new(workspace_root);
+        let valid_files: HashSet<PathBuf> = HashSet::new(); // 全エントリ skip され得るが global は無関係
+        loader.load(&restored, &valid_files).unwrap();
+
+        // resolved() が同じ結果になっていること
+        assert_eq!(original.interpolate.resolved(), restored.interpolate.resolved());
+        assert_eq!(restored.interpolate.resolved().0, "<%".to_string());
+        assert_eq!(restored.interpolate.resolved().1, "%>".to_string());
+
+        // 各 URI のエントリも復元されていること
+        let mut entries = restored.interpolate.iter_js_detected_for_cache();
+        entries.sort_by(|a, b| a.0.cmp(&b.0));
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].0, uri_a);
+        assert_eq!(entries[0].1, Some("<%".to_string()));
+        assert_eq!(entries[0].2, Some("%>".to_string()));
+        assert_eq!(entries[1].0, uri_b);
+        assert_eq!(entries[1].1, Some("[[".to_string()));
+        assert_eq!(entries[1].2, None);
+    }
+
+    #[test]
+    fn empty_interpolate_round_trip() {
+        // 検出値が無いケースでも save/load が壊れないことを確認 (後方互換性)
+        let tmp = TempDir::new().unwrap();
+        let workspace_root = tmp.path();
+
+        let original = Index::new();
+        let writer = CacheWriter::new(workspace_root);
+        writer.save_full(&original, &HashMap::new()).unwrap();
+
+        let restored = Index::new();
+        let loader = CacheLoader::new(workspace_root);
+        loader.load(&restored, &HashSet::new()).unwrap();
+
+        // デフォルトに戻る
+        assert_eq!(
+            restored.interpolate.resolved(),
+            ("{{".to_string(), "}}".to_string())
+        );
     }
 }

--- a/src/config/ajs_config.rs
+++ b/src/config/ajs_config.rs
@@ -6,10 +6,14 @@ use serde::Deserialize;
 use super::path_matcher::PathMatcher;
 
 /// ajsconfig.json の設定
+///
+/// 注意: 旧来は `interpolate.startSymbol` / `interpolate.endSymbol` を持って
+/// いたが、現在は AngularJS ソースの `$interpolateProvider.startSymbol(...)` /
+/// `.endSymbol(...)` から動的に解決するため当該フィールドは廃止した。
+/// 古い `ajsconfig.json` に `interpolate` フィールドが残っていても、`serde` の
+/// 標準動作で未知フィールドとして黙って無視される。
 #[derive(Debug, Clone, Deserialize)]
 pub struct AjsConfig {
-    #[serde(default)]
-    pub interpolate: InterpolateConfig,
     /// 解析対象のglobパターン（空の場合は全ファイル対象）
     #[serde(default)]
     pub include: Vec<String>,
@@ -69,37 +73,9 @@ fn default_exclude() -> Vec<String> {
     ]
 }
 
-/// interpolate記号の設定
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct InterpolateConfig {
-    #[serde(default = "default_start_symbol")]
-    pub start_symbol: String,
-    #[serde(default = "default_end_symbol")]
-    pub end_symbol: String,
-}
-
-fn default_start_symbol() -> String {
-    "{{".to_string()
-}
-
-fn default_end_symbol() -> String {
-    "}}".to_string()
-}
-
-impl Default for InterpolateConfig {
-    fn default() -> Self {
-        Self {
-            start_symbol: default_start_symbol(),
-            end_symbol: default_end_symbol(),
-        }
-    }
-}
-
 impl Default for AjsConfig {
     fn default() -> Self {
         Self {
-            interpolate: InterpolateConfig::default(),
             include: Vec::new(),
             exclude: default_exclude(),
             cache: false,
@@ -149,29 +125,31 @@ mod tests {
     #[test]
     fn test_default_config() {
         let config = AjsConfig::default();
-        assert_eq!(config.interpolate.start_symbol, "{{");
-        assert_eq!(config.interpolate.end_symbol, "}}");
+        assert!(config.include.is_empty());
+        assert!(!config.cache);
     }
 
     #[test]
-    fn test_parse_config() {
+    fn test_legacy_interpolate_field_is_ignored() {
+        // 旧フォーマットの ajsconfig.json (interpolate フィールドあり) を読み込んでも
+        // serde は未知フィールドを無視するのでパース成功するべき。
+        // interpolate 解決は AngularJS ソース由来に一本化されているのでこの値は使われない。
         let json = r#"{
             "interpolate": {
                 "startSymbol": "[[",
                 "endSymbol": "]]"
-            }
+            },
+            "cache": true
         }"#;
         let config: AjsConfig = serde_json::from_str(json).unwrap();
-        assert_eq!(config.interpolate.start_symbol, "[[");
-        assert_eq!(config.interpolate.end_symbol, "]]");
+        assert!(config.cache, "interpolate フィールドがあっても他フィールドは正しく読み込まれる");
     }
 
     #[test]
     fn test_empty_config() {
         let json = r#"{}"#;
         let config: AjsConfig = serde_json::from_str(json).unwrap();
-        assert_eq!(config.interpolate.start_symbol, "{{");
-        assert_eq!(config.interpolate.end_symbol, "}}");
+        assert!(config.include.is_empty());
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,5 +1,5 @@
 pub mod ajs_config;
 pub mod path_matcher;
 
-pub use ajs_config::{AjsConfig, DiagnosticsConfig, InterpolateConfig};
+pub use ajs_config::{AjsConfig, DiagnosticsConfig};
 pub use path_matcher::PathMatcher;

--- a/src/index/interpolate_store.rs
+++ b/src/index/interpolate_store.rs
@@ -1,0 +1,190 @@
+use std::sync::RwLock;
+
+use dashmap::DashMap;
+use tower_lsp::lsp_types::Url;
+
+/// `js_detected` から取り出した 1 エントリ。`(URI, (start_symbol, end_symbol))`。
+type DetectedEntry = (Url, (Option<String>, Option<String>));
+
+/// AngularJS の interpolate 記号 (`{{` / `}}` または `$interpolateProvider` で
+/// カスタマイズされた値) を解決するストア。
+///
+/// 解決順:
+/// 1. JS ソース中で検出された `$interpolateProvider.startSymbol(...)` /
+///    `$interpolateProvider.endSymbol(...)` の値 (URI ごとに保持)
+/// 2. `ajsconfig.json` の `interpolate.startSymbol` / `interpolate.endSymbol`
+///    (フォールバック)
+/// 3. AngularJS デフォルトの `{{` / `}}`
+pub struct InterpolateStore {
+    /// JS から検出された symbols (URI → (start, end))。
+    /// 各 URI は `$interpolateProvider.startSymbol(...)` か
+    /// `$interpolateProvider.endSymbol(...)` のどちらか/両方を持ち得る。
+    js_detected: DashMap<Url, (Option<String>, Option<String>)>,
+    /// `ajsconfig.json` の `interpolate` 設定 (フォールバック)。
+    /// 起動時に `set_config_fallback` で設定される。
+    /// 初期値は AngularJS デフォルトの `{{` / `}}`。
+    config_fallback: RwLock<(String, String)>,
+}
+
+impl InterpolateStore {
+    pub fn new() -> Self {
+        Self {
+            js_detected: DashMap::new(),
+            config_fallback: RwLock::new(("{{".to_string(), "}}".to_string())),
+        }
+    }
+
+    /// `ajsconfig.json` の interpolate 設定をフォールバックとして登録する
+    pub fn set_config_fallback(&self, start: String, end: String) {
+        if let Ok(mut c) = self.config_fallback.write() {
+            *c = (start, end);
+        }
+    }
+
+    /// 指定 URI で `$interpolateProvider.startSymbol(...)` を検出した
+    pub fn set_start_symbol(&self, uri: Url, symbol: String) {
+        let mut entry = self.js_detected.entry(uri).or_insert((None, None));
+        entry.0 = Some(symbol);
+    }
+
+    /// 指定 URI で `$interpolateProvider.endSymbol(...)` を検出した
+    pub fn set_end_symbol(&self, uri: Url, symbol: String) {
+        let mut entry = self.js_detected.entry(uri).or_insert((None, None));
+        entry.1 = Some(symbol);
+    }
+
+    /// 指定 URI の検出値を削除 (clear_document 時)
+    pub fn clear_document(&self, uri: &Url) {
+        self.js_detected.remove(uri);
+    }
+
+    /// 全エントリをクリア
+    pub fn clear_all(&self) {
+        self.js_detected.clear();
+    }
+
+    /// 解決された (start_symbol, end_symbol) を返す。
+    ///
+    /// JS 検出値 → ajsconfig フォールバック → デフォルト の順で解決する。
+    /// 複数の URI が JS 検出値を持つ場合は URI 順 (lexicographic) で最初に
+    /// 見つかった非 None 値を採用する (決定的)。
+    /// start と end は別々に解決されるので、片方だけ JS 検出されたケースも
+    /// 正しく扱える。
+    pub fn resolved(&self) -> (String, String) {
+        // 決定的にするため URI でソートして走査
+        let mut entries: Vec<DetectedEntry> = self
+            .js_detected
+            .iter()
+            .map(|e| (e.key().clone(), e.value().clone()))
+            .collect();
+        entries.sort_by(|a, b| a.0.cmp(&b.0));
+
+        let mut start: Option<String> = None;
+        let mut end: Option<String> = None;
+        for (_, (s, e)) in entries {
+            if start.is_none() && s.is_some() {
+                start = s;
+            }
+            if end.is_none() && e.is_some() {
+                end = e;
+            }
+            if start.is_some() && end.is_some() {
+                break;
+            }
+        }
+
+        let fallback = self
+            .config_fallback
+            .read()
+            .ok()
+            .map(|c| c.clone())
+            .unwrap_or_else(|| ("{{".to_string(), "}}".to_string()));
+
+        (
+            start.unwrap_or(fallback.0),
+            end.unwrap_or(fallback.1),
+        )
+    }
+}
+
+impl Default for InterpolateStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn url(path: &str) -> Url {
+        Url::parse(&format!("file://{}", path)).unwrap()
+    }
+
+    #[test]
+    fn defaults_to_double_curly() {
+        let store = InterpolateStore::new();
+        assert_eq!(store.resolved(), ("{{".to_string(), "}}".to_string()));
+    }
+
+    #[test]
+    fn config_fallback_overrides_default() {
+        let store = InterpolateStore::new();
+        store.set_config_fallback("[[".to_string(), "]]".to_string());
+        assert_eq!(store.resolved(), ("[[".to_string(), "]]".to_string()));
+    }
+
+    #[test]
+    fn js_detected_overrides_config_fallback() {
+        let store = InterpolateStore::new();
+        store.set_config_fallback("[[".to_string(), "]]".to_string());
+        let uri = url("/app/config.js");
+        store.set_start_symbol(uri.clone(), "{<".to_string());
+        store.set_end_symbol(uri, ">}".to_string());
+        assert_eq!(store.resolved(), ("{<".to_string(), ">}".to_string()));
+    }
+
+    #[test]
+    fn partial_js_detected_falls_back_for_missing_side() {
+        // start のみ JS 検出、end は config フォールバック
+        let store = InterpolateStore::new();
+        store.set_config_fallback("[[".to_string(), "]]".to_string());
+        let uri = url("/app/config.js");
+        store.set_start_symbol(uri, "{<".to_string());
+        // end_symbol は未設定
+        assert_eq!(store.resolved(), ("{<".to_string(), "]]".to_string()));
+    }
+
+    #[test]
+    fn clear_document_removes_entry() {
+        let store = InterpolateStore::new();
+        let uri = url("/app/config.js");
+        store.set_start_symbol(uri.clone(), "{<".to_string());
+        store.set_end_symbol(uri.clone(), ">}".to_string());
+        assert_eq!(store.resolved(), ("{<".to_string(), ">}".to_string()));
+
+        store.clear_document(&uri);
+        // 検出値が消えたのでデフォルトに戻る
+        assert_eq!(store.resolved(), ("{{".to_string(), "}}".to_string()));
+    }
+
+    #[test]
+    fn multiple_uris_first_in_uri_order_wins() {
+        // 同じシンボルを複数 JS が宣言した場合、URI 順で最初に出るものを採用 (決定的)
+        let store = InterpolateStore::new();
+        // /a.js が後、/b.js が先になるよう URI を選ぶ
+        store.set_start_symbol(url("/b.js"), "B<".to_string());
+        store.set_start_symbol(url("/a.js"), "A<".to_string());
+        // /a.js が URI sort で先 → A< が採用
+        assert_eq!(store.resolved().0, "A<".to_string());
+    }
+
+    #[test]
+    fn split_across_uris_each_contributes() {
+        // 1 URI が start のみ、別 URI が end のみ宣言したケース
+        let store = InterpolateStore::new();
+        store.set_start_symbol(url("/a.js"), "<%".to_string());
+        store.set_end_symbol(url("/b.js"), "%>".to_string());
+        assert_eq!(store.resolved(), ("<%".to_string(), "%>".to_string()));
+    }
+}

--- a/src/index/interpolate_store.rs
+++ b/src/index/interpolate_store.rs
@@ -1,5 +1,3 @@
-use std::sync::RwLock;
-
 use dashmap::DashMap;
 use tower_lsp::lsp_types::Url;
 
@@ -12,32 +10,21 @@ type DetectedEntry = (Url, (Option<String>, Option<String>));
 /// 解決順:
 /// 1. JS ソース中で検出された `$interpolateProvider.startSymbol(...)` /
 ///    `$interpolateProvider.endSymbol(...)` の値 (URI ごとに保持)
-/// 2. `ajsconfig.json` の `interpolate.startSymbol` / `interpolate.endSymbol`
-///    (フォールバック)
-/// 3. AngularJS デフォルトの `{{` / `}}`
+/// 2. AngularJS デフォルトの `{{` / `}}`
+///
+/// 旧来は `ajsconfig.json` の `interpolate.startSymbol/endSymbol` を
+/// フォールバックとしていたが、現在は AngularJS 構文からの解決に一本化している。
 pub struct InterpolateStore {
     /// JS から検出された symbols (URI → (start, end))。
     /// 各 URI は `$interpolateProvider.startSymbol(...)` か
     /// `$interpolateProvider.endSymbol(...)` のどちらか/両方を持ち得る。
     js_detected: DashMap<Url, (Option<String>, Option<String>)>,
-    /// `ajsconfig.json` の `interpolate` 設定 (フォールバック)。
-    /// 起動時に `set_config_fallback` で設定される。
-    /// 初期値は AngularJS デフォルトの `{{` / `}}`。
-    config_fallback: RwLock<(String, String)>,
 }
 
 impl InterpolateStore {
     pub fn new() -> Self {
         Self {
             js_detected: DashMap::new(),
-            config_fallback: RwLock::new(("{{".to_string(), "}}".to_string())),
-        }
-    }
-
-    /// `ajsconfig.json` の interpolate 設定をフォールバックとして登録する
-    pub fn set_config_fallback(&self, start: String, end: String) {
-        if let Ok(mut c) = self.config_fallback.write() {
-            *c = (start, end);
         }
     }
 
@@ -90,7 +77,7 @@ impl InterpolateStore {
 
     /// 解決された (start_symbol, end_symbol) を返す。
     ///
-    /// JS 検出値 → ajsconfig フォールバック → デフォルト の順で解決する。
+    /// JS 検出値 → AngularJS デフォルト (`{{` / `}}`) の順で解決する。
     /// 複数の URI が JS 検出値を持つ場合は URI 順 (lexicographic) で最初に
     /// 見つかった非 None 値を採用する (決定的)。
     /// start と end は別々に解決されるので、片方だけ JS 検出されたケースも
@@ -118,16 +105,9 @@ impl InterpolateStore {
             }
         }
 
-        let fallback = self
-            .config_fallback
-            .read()
-            .ok()
-            .map(|c| c.clone())
-            .unwrap_or_else(|| ("{{".to_string(), "}}".to_string()));
-
         (
-            start.unwrap_or(fallback.0),
-            end.unwrap_or(fallback.1),
+            start.unwrap_or_else(|| "{{".to_string()),
+            end.unwrap_or_else(|| "}}".to_string()),
         )
     }
 }
@@ -153,16 +133,8 @@ mod tests {
     }
 
     #[test]
-    fn config_fallback_overrides_default() {
+    fn js_detected_overrides_default() {
         let store = InterpolateStore::new();
-        store.set_config_fallback("[[".to_string(), "]]".to_string());
-        assert_eq!(store.resolved(), ("[[".to_string(), "]]".to_string()));
-    }
-
-    #[test]
-    fn js_detected_overrides_config_fallback() {
-        let store = InterpolateStore::new();
-        store.set_config_fallback("[[".to_string(), "]]".to_string());
         let uri = url("/app/config.js");
         store.set_start_symbol(uri.clone(), "{<".to_string());
         store.set_end_symbol(uri, ">}".to_string());
@@ -170,14 +142,13 @@ mod tests {
     }
 
     #[test]
-    fn partial_js_detected_falls_back_for_missing_side() {
-        // start のみ JS 検出、end は config フォールバック
+    fn partial_js_detected_falls_back_to_default_for_missing_side() {
+        // start のみ JS 検出、end はデフォルトの `}}` にフォールバック
         let store = InterpolateStore::new();
-        store.set_config_fallback("[[".to_string(), "]]".to_string());
         let uri = url("/app/config.js");
         store.set_start_symbol(uri, "{<".to_string());
-        // end_symbol は未設定
-        assert_eq!(store.resolved(), ("{<".to_string(), "]]".to_string()));
+        // end_symbol は未設定 → default `}}`
+        assert_eq!(store.resolved(), ("{<".to_string(), "}}".to_string()));
     }
 
     #[test]

--- a/src/index/interpolate_store.rs
+++ b/src/index/interpolate_store.rs
@@ -63,6 +63,31 @@ impl InterpolateStore {
         self.js_detected.clear();
     }
 
+    /// キャッシュ書き出し用に全 JS 検出エントリを取り出す。
+    ///
+    /// 返り値は `(URI, start_symbol, end_symbol)` の Vec。順序は不定。
+    /// `config_fallback` は `ajsconfig.json` から起動時に再構築されるので
+    /// キャッシュ対象には含めない。
+    pub fn iter_js_detected_for_cache(&self) -> Vec<(Url, Option<String>, Option<String>)> {
+        self.js_detected
+            .iter()
+            .map(|e| {
+                let (s, end) = e.value().clone();
+                (e.key().clone(), s, end)
+            })
+            .collect()
+    }
+
+    /// キャッシュ復元用にエントリを丸ごと書き戻す。
+    /// 既存エントリがあれば上書きする (start/end どちらか片方だけ既存値があるケースは
+    /// 通常の `set_*_symbol` 経路で発生するが、復元時は丸ごとの上書きで十分)。
+    pub fn restore_from_cache(&self, uri: Url, start: Option<String>, end: Option<String>) {
+        if start.is_none() && end.is_none() {
+            return;
+        }
+        self.js_detected.insert(uri, (start, end));
+    }
+
     /// 解決された (start_symbol, end_symbol) を返す。
     ///
     /// JS 検出値 → ajsconfig フォールバック → デフォルト の順で解決する。
@@ -186,5 +211,55 @@ mod tests {
         store.set_start_symbol(url("/a.js"), "<%".to_string());
         store.set_end_symbol(url("/b.js"), "%>".to_string());
         assert_eq!(store.resolved(), ("<%".to_string(), "%>".to_string()));
+    }
+
+    #[test]
+    fn iter_js_detected_for_cache_returns_all_entries() {
+        let store = InterpolateStore::new();
+        store.set_start_symbol(url("/a.js"), "<%".to_string());
+        store.set_end_symbol(url("/a.js"), "%>".to_string());
+        store.set_start_symbol(url("/b.js"), "[[".to_string());
+
+        let mut entries = store.iter_js_detected_for_cache();
+        entries.sort_by(|a, b| a.0.cmp(&b.0));
+
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].0, url("/a.js"));
+        assert_eq!(entries[0].1, Some("<%".to_string()));
+        assert_eq!(entries[0].2, Some("%>".to_string()));
+        assert_eq!(entries[1].0, url("/b.js"));
+        assert_eq!(entries[1].1, Some("[[".to_string()));
+        assert_eq!(entries[1].2, None);
+    }
+
+    #[test]
+    fn restore_from_cache_round_trip() {
+        // 1. 元の store を構築
+        let store = InterpolateStore::new();
+        store.set_start_symbol(url("/a.js"), "<%".to_string());
+        store.set_end_symbol(url("/a.js"), "%>".to_string());
+        store.set_start_symbol(url("/b.js"), "[[".to_string());
+        let snapshot = store.iter_js_detected_for_cache();
+
+        // 2. 別 store に復元
+        let restored = InterpolateStore::new();
+        for (uri, s, e) in snapshot {
+            restored.restore_from_cache(uri, s, e);
+        }
+
+        // 3. resolved() が同じ結果になること
+        assert_eq!(store.resolved(), restored.resolved());
+
+        // /a.js の start/end が両方復元されていること
+        let entries = restored.iter_js_detected_for_cache();
+        assert_eq!(entries.len(), 2);
+    }
+
+    #[test]
+    fn restore_from_cache_skips_empty_entries() {
+        let store = InterpolateStore::new();
+        store.restore_from_cache(url("/a.js"), None, None);
+        // 空エントリはスキップされる
+        assert!(store.iter_js_detected_for_cache().is_empty());
     }
 }

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -3,6 +3,7 @@ pub mod controller_store;
 pub mod definition_store;
 pub mod export_store;
 pub mod html_store;
+pub mod interpolate_store;
 mod query;
 pub mod template_store;
 
@@ -11,11 +12,12 @@ pub use controller_store::ControllerStore;
 pub use definition_store::DefinitionStore;
 pub use export_store::ExportStore;
 pub use html_store::HtmlStore;
+pub use interpolate_store::InterpolateStore;
 pub use template_store::TemplateStore;
 
 use tower_lsp::lsp_types::Url;
 
-/// Index ファサード — 6つの専門ストアを束ねる
+/// Index ファサード — 7つの専門ストアを束ねる
 pub struct Index {
     pub definitions: DefinitionStore,
     pub controllers: ControllerStore,
@@ -23,6 +25,7 @@ pub struct Index {
     pub html: HtmlStore,
     pub exports: ExportStore,
     pub components: ComponentStore,
+    pub interpolate: InterpolateStore,
 }
 
 impl Index {
@@ -34,6 +37,7 @@ impl Index {
             html: HtmlStore::new(),
             exports: ExportStore::new(),
             components: ComponentStore::new(),
+            interpolate: InterpolateStore::new(),
         }
     }
 
@@ -45,6 +49,7 @@ impl Index {
         self.html.clear_document(uri);
         self.exports.clear_document(uri);
         self.components.clear_document(uri);
+        self.interpolate.clear_document(uri);
     }
 
     /// 全てのインデックスデータをクリア
@@ -55,6 +60,7 @@ impl Index {
         self.html.clear_all();
         self.exports.clear_all();
         self.components.clear_all();
+        self.interpolate.clear_all();
     }
 
     /// HTML参照情報のみをクリア（Pass 3で収集する情報）

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1198,14 +1198,21 @@ impl LanguageServer for Backend {
                 let config = AjsConfig::load_from_dir(&path);
                 cache_enabled = config.cache;
 
-                self.html_analyzer
-                    .set_interpolate_config(config.interpolate.clone());
+                // ajsconfig.json の `interpolate` 設定はフォールバック扱いになった
+                // (主要な解決経路は JS 中の `$interpolateProvider.startSymbol/endSymbol`)。
+                // 互換のために値を Index::interpolate に登録しておく。
+                self.index.interpolate.set_config_fallback(
+                    config.interpolate.start_symbol.clone(),
+                    config.interpolate.end_symbol.clone(),
+                );
                 *self.diagnostics_config.write().await = config.diagnostics.clone();
                 self.client
                     .log_message(
                         MessageType::INFO,
                         format!(
-                            "Interpolate symbols: {} ... {}",
+                            "Interpolate fallback (ajsconfig.json): {} ... {} \
+                             — JS source `$interpolateProvider.startSymbol/endSymbol` \
+                             が検出されればそちらを優先",
                             config.interpolate.start_symbol, config.interpolate.end_symbol
                         ),
                     )

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1198,25 +1198,9 @@ impl LanguageServer for Backend {
                 let config = AjsConfig::load_from_dir(&path);
                 cache_enabled = config.cache;
 
-                // ajsconfig.json の `interpolate` 設定はフォールバック扱いになった
-                // (主要な解決経路は JS 中の `$interpolateProvider.startSymbol/endSymbol`)。
-                // 互換のために値を Index::interpolate に登録しておく。
-                self.index.interpolate.set_config_fallback(
-                    config.interpolate.start_symbol.clone(),
-                    config.interpolate.end_symbol.clone(),
-                );
+                // interpolate 記号は JS の `$interpolateProvider.startSymbol/endSymbol`
+                // から動的に解決する (ajsconfig.json 経由の設定経路は撤廃済み)。
                 *self.diagnostics_config.write().await = config.diagnostics.clone();
-                self.client
-                    .log_message(
-                        MessageType::INFO,
-                        format!(
-                            "Interpolate fallback (ajsconfig.json): {} ... {} \
-                             — JS source `$interpolateProvider.startSymbol/endSymbol` \
-                             が検出されればそちらを優先",
-                            config.interpolate.start_symbol, config.interpolate.end_symbol
-                        ),
-                    )
-                    .await;
 
                 if !config.include.is_empty() {
                     self.client

--- a/tests/angularjs_common_syntax_test.rs
+++ b/tests/angularjs_common_syntax_test.rs
@@ -1255,6 +1255,62 @@ angular.module('app', []).controller('RefCtrl', ['$scope', function($scope) {
     assert!(has_do_something_ref, "ng-clickのdoSomething()参照が認識されるべき");
 }
 
+#[test]
+fn test_html_interpolation_uses_custom_symbols_from_js() {
+    // JS で `$interpolateProvider.startSymbol/endSymbol` をカスタマイズし、
+    // HTML 側で同じカスタム記号でインターポレーションを書いた場合、
+    // 参照が正しく認識されることを確認 (HTML analyzer が Index::interpolate.resolved()
+    // から動的に記号を取得することの統合テスト)
+    let js = r#"
+angular.module('app', [])
+    .config(['$interpolateProvider', function($interpolateProvider) {
+        $interpolateProvider.startSymbol('[[');
+        $interpolateProvider.endSymbol(']]');
+    }])
+    .controller('CustomCtrl', ['$scope', function($scope) {
+        $scope.title = 'Hello';
+    }]);
+"#;
+    let html = r#"
+<div ng-controller="CustomCtrl">
+    <h1>[[ title ]]</h1>
+</div>
+"#;
+    let index = analyze_html(js, html);
+
+    let html_uri = Url::parse("file:///test.html").unwrap();
+    let scope_refs = index.html.get_html_scope_references(&html_uri);
+    assert!(
+        scope_refs.iter().any(|r| r.property_path == "title"),
+        "JS で設定された custom interpolate 記号 [[ ]] でも参照認識されるべき, refs = {:?}",
+        scope_refs.iter().map(|r| &r.property_path).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_html_interpolation_default_when_not_configured_in_js() {
+    // JS で `$interpolateProvider` を触っていない場合はデフォルト `{{ }}` で解析される
+    let js = r#"
+angular.module('app', [])
+    .controller('DefaultCtrl', ['$scope', function($scope) {
+        $scope.message = 'World';
+    }]);
+"#;
+    let html = r#"
+<div ng-controller="DefaultCtrl">
+    <p>{{ message }}</p>
+</div>
+"#;
+    let index = analyze_html(js, html);
+
+    let html_uri = Url::parse("file:///test.html").unwrap();
+    let scope_refs = index.html.get_html_scope_references(&html_uri);
+    assert!(
+        scope_refs.iter().any(|r| r.property_path == "message"),
+        "JS で interpolateProvider 未設定なら default `{{{{ }}}}` で参照認識されるべき"
+    );
+}
+
 // ============================================================
 // 21. 網羅的テスト：テストファイル全体の解析
 // ============================================================

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -70,8 +70,8 @@ Create an `ajsconfig.json` file in your project root to customize behavior:
 |--------|------|---------|-------------|
 | `include` | `string[]` | `[]` (all files) | Glob patterns for files to analyze. If empty, all files are included. |
 | `exclude` | `string[]` | (see below) | Glob patterns for files/directories to exclude. |
-| `interpolate.startSymbol` | `string` | `{{` | AngularJS interpolation start symbol. |
-| `interpolate.endSymbol` | `string` | `}}` | AngularJS interpolation end symbol. |
+| `interpolate.startSymbol` | `string` | `{{` | AngularJS interpolation start symbol. **Fallback only**: the language server first detects this from `$interpolateProvider.startSymbol(...)` in your JS source. See note below. |
+| `interpolate.endSymbol` | `string` | `}}` | AngularJS interpolation end symbol. **Fallback only** (same as above). |
 | `cache` | `boolean` | `true` | Enable caching of parsed symbols. Cache is stored in `.angularjs-lsp/cache/`. |
 | `diagnostics.enabled` | `boolean` | `true` | Enable diagnostics for undefined scope properties and local variables. |
 | `diagnostics.severity` | `string` | `"warning"` | Severity level: `"error"`, `"warning"`, `"hint"`, or `"information"`. |
@@ -84,6 +84,22 @@ By default, the following patterns are excluded:
 - `**/dist/**`
 - `**/build/**`
 - `**/.*/**` (hidden files/directories)
+
+### Interpolation symbols
+
+The language server resolves `{{ }}` (or your custom delimiters) in this order:
+
+1. `$interpolateProvider.startSymbol(...)` / `.endSymbol(...)` calls detected in your JS source —
+   no LSP-specific config needed. Both implicit DI and array-style DI rename are recognized:
+
+   ```js
+   angular.module('app').config(['$interpolateProvider', function(ip) {
+     ip.startSymbol('[[').endSymbol(']]');
+   }]);
+   ```
+
+2. `interpolate.startSymbol` / `interpolate.endSymbol` in `ajsconfig.json` (fallback).
+3. AngularJS default `{{` / `}}`.
 
 ## Commands
 

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -60,11 +60,6 @@ Create an `ajsconfig.json` file in your project root to customize behavior:
 }
 ```
 
-> **Note**: Interpolation delimiters (`{{` / `}}`) are **not** configured here.
-> They are detected from `$interpolateProvider.startSymbol(...)` /
-> `.endSymbol(...)` calls in your AngularJS source.
-> See [Interpolation symbols](#interpolation-symbols) below.
-
 ### Options
 
 | Option | Type | Default | Description |
@@ -83,20 +78,6 @@ By default, the following patterns are excluded:
 - `**/dist/**`
 - `**/build/**`
 - `**/.*/**` (hidden files/directories)
-
-### Interpolation symbols
-
-The language server detects `{{ }}` (or your custom delimiters) from `$interpolateProvider`
-calls in your AngularJS source — no LSP-specific config is needed. Implicit DI, array-style
-DI rename, and chained calls are all recognized:
-
-```js
-angular.module('app').config(['$interpolateProvider', function(ip) {
-  ip.startSymbol('[[').endSymbol(']]');
-}]);
-```
-
-If no such call is found, the AngularJS default `{{` / `}}` is used.
 
 ## Commands
 

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -52,10 +52,6 @@ Create an `ajsconfig.json` file in your project root to customize behavior:
 {
   "include": ["src/**/*.js", "app/**/*.js"],
   "exclude": ["**/test/**", "**/vendor/**"],
-  "interpolate": {
-    "startSymbol": "{{",
-    "endSymbol": "}}"
-  },
   "cache": true,
   "diagnostics": {
     "enabled": true,
@@ -64,14 +60,17 @@ Create an `ajsconfig.json` file in your project root to customize behavior:
 }
 ```
 
+> **Note**: Interpolation delimiters (`{{` / `}}`) are **not** configured here.
+> They are detected from `$interpolateProvider.startSymbol(...)` /
+> `.endSymbol(...)` calls in your AngularJS source.
+> See [Interpolation symbols](#interpolation-symbols) below.
+
 ### Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `include` | `string[]` | `[]` (all files) | Glob patterns for files to analyze. If empty, all files are included. |
 | `exclude` | `string[]` | (see below) | Glob patterns for files/directories to exclude. |
-| `interpolate.startSymbol` | `string` | `{{` | AngularJS interpolation start symbol. **Fallback only**: the language server first detects this from `$interpolateProvider.startSymbol(...)` in your JS source. See note below. |
-| `interpolate.endSymbol` | `string` | `}}` | AngularJS interpolation end symbol. **Fallback only** (same as above). |
 | `cache` | `boolean` | `true` | Enable caching of parsed symbols. Cache is stored in `.angularjs-lsp/cache/`. |
 | `diagnostics.enabled` | `boolean` | `true` | Enable diagnostics for undefined scope properties and local variables. |
 | `diagnostics.severity` | `string` | `"warning"` | Severity level: `"error"`, `"warning"`, `"hint"`, or `"information"`. |
@@ -87,19 +86,17 @@ By default, the following patterns are excluded:
 
 ### Interpolation symbols
 
-The language server resolves `{{ }}` (or your custom delimiters) in this order:
+The language server detects `{{ }}` (or your custom delimiters) from `$interpolateProvider`
+calls in your AngularJS source — no LSP-specific config is needed. Implicit DI, array-style
+DI rename, and chained calls are all recognized:
 
-1. `$interpolateProvider.startSymbol(...)` / `.endSymbol(...)` calls detected in your JS source —
-   no LSP-specific config needed. Both implicit DI and array-style DI rename are recognized:
+```js
+angular.module('app').config(['$interpolateProvider', function(ip) {
+  ip.startSymbol('[[').endSymbol(']]');
+}]);
+```
 
-   ```js
-   angular.module('app').config(['$interpolateProvider', function(ip) {
-     ip.startSymbol('[[').endSymbol(']]');
-   }]);
-   ```
-
-2. `interpolate.startSymbol` / `interpolate.endSymbol` in `ajsconfig.json` (fallback).
-3. AngularJS default `{{` / `}}`.
+If no such call is found, the AngularJS default `{{` / `}}` is used.
 
 ## Commands
 


### PR DESCRIPTION
## Summary

- HTML 内の \`{{ ... }}\` インターポレーション記号を **AngularJS ソース中の \`\$interpolateProvider.startSymbol/endSymbol\` から動的に解決** するように変更
- 旧来の \`ajsconfig.json\` の \`interpolate\` 設定は **フォールバック** として残置 (後方互換)

> ⚠️ **Stacked on PR #33**: \`is_provider_receiver\` を流用するため。base は \`fix/route-state-provider-receiver-check\`。PR #33 マージ後に GitHub が自動で base を master に切り替える。

## 背景

ユーザーリクエスト: \`ajsconfig.json\` で設定された値ではなく **AngularJS 構文** から interpolate 記号を解決してほしい。

実プロジェクトでは:
\`\`\`js
angular.module('app', [])
  .config(['\$interpolateProvider', function(\$interpolateProvider) {
    \$interpolateProvider.startSymbol('[[');
    \$interpolateProvider.endSymbol(']]');
  }]);
\`\`\`
のように JS で記号を変えるパターンが一般的。LSP が \`ajsconfig.json\` 経由で別途設定を要求するのは冗長 + 同期ずれの原因。

## 変更内容

### 解決ロジック (新規 \`InterpolateStore\`)

| 優先度 | ソース |
|---|---|
| 1 | JS ソース中の \`\$interpolateProvider.startSymbol/endSymbol\` (URI ごとに保持) |
| 2 | \`ajsconfig.json\` の \`interpolate\` 設定 (フォールバック) |
| 3 | AngularJS デフォルト \`{{\` / \`}}\` |

\`start\` と \`end\` は別々に解決されるため、片方だけ JS 検出されたケースも正しく扱える。複数 URI が JS 検出値を持つ場合は URI 順 (lexicographic) で決定的に選ぶ。

### JS 解析側の検出

\`analyze_call_expression\` に \`startSymbol\` / \`endSymbol\` の dispatch を追加:
\`\`\`rust
"startSymbol" | "endSymbol" => {
    if self.is_provider_receiver(callee, source, ctx, "interpolateProvider") {
        self.extract_interpolate_symbol_call(node, source, uri, method);
    }
}
\`\`\`

PR #33 で導入した \`is_provider_receiver\` を再利用してレシーバ検証:
- 直接マッチ (\`\$interpolateProvider.startSymbol(...)\`)
- DI rename (\`['\$interpolateProvider', function(ip) { ip.startSymbol(...) }]\`)
- チェイン (\`\$interpolateProvider.startSymbol().endSymbol()\`)

文字列リテラル以外 (動的引数) は無視する。

### HTML 解析側

\`HtmlAngularJsAnalyzer\` の \`interpolate: RwLock<InterpolateConfig>\` フィールドを撤廃。\`get_interpolate_symbols()\` を \`self.index.interpolate.resolved()\` に置換し、Index を single source of truth に集約。

### Server

\`set_interpolate_config\` の呼び出しを撤去し、\`ajsconfig.json\` の \`interpolate\` 値を \`Index::interpolate.set_config_fallback(...)\` に流し込む。

## 後方互換性

- \`ajsconfig.json\` の \`interpolate\` 設定は引き続き有効 (フォールバックとして動作)
- JS で \`\$interpolateProvider\` を呼んでいないプロジェクトは挙動が変わらない (デフォルト \`{{ }}\`)
- \`ajsconfig.json\` で記号をカスタムしているプロジェクトもそのまま動く (フォールバック経路)

## Test plan

### 単体テスト 8 ケース (\`analyzer/js/tests/mod.rs\`)
- 配列 DI で startSymbol/endSymbol → 検出
- 配列 DI で receiver rename (\`ip.startSymbol\`) → 検出
- 暗黙 DI → 検出
- 動的引数 (変数参照) → 無視
- 関係ないオブジェクトの \`.startSymbol()\` → 無視
- start のみ JS 検出 → end はフォールバック
- チェイン呼び出し \`.startSymbol().endSymbol()\` → 両方検出
- clear_document → 検出値がクリアされる

### 統合テスト 2 ケース (\`tests/angularjs_common_syntax_test.rs\`)
- JS で \`[[\`/\`]]\` を設定 → HTML \`<h1>[[ title ]]</h1>\` のスコープ参照認識
- JS で未設定 → HTML \`{{ message }}\` が default で認識

### InterpolateStore 単体テスト 7 ケース (\`index/interpolate_store.rs\`)
- デフォルト / config fallback / JS detected 優先 / partial fallback /
  clear_document / 複数 URI 決定的順 / start と end が別 URI

- [x] \`cargo test\` 全件 pass (lib 144 / 統合 117 + 2)
- [x] \`cargo clippy\` 変更ファイルに新規警告なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)