### PR TITLE
chore: release v0.3.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,13 +121,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # VSCode extension packaging (optional)
+  # VSCode extension packaging + Open VSX publish
   vscode-extension:
     name: Package VSCode Extension
     needs: release
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      OVSX_PAT: ${{ secrets.OVSX_PAT }}
 
     steps:
       - name: Checkout
@@ -152,3 +154,13 @@ jobs:
           files: vscode-extension/*.vsix
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Open VSX publish (skipped if OVSX_PAT secret is not configured)
+      - name: Publish to Open VSX
+        if: env.OVSX_PAT != ''
+        working-directory: vscode-extension
+        run: npx ovsx publish *.vsix -p "$OVSX_PAT"
+
+      - name: Skip Open VSX publish (no OVSX_PAT secret)
+        if: env.OVSX_PAT == ''
+        run: echo "::warning::OVSX_PAT secret not set, skipping Open VSX publish. Add it via gh secret set OVSX_PAT to enable automatic publishing."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "angularjs-lsp"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "bincode",
  "dashmap 6.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "angularjs-lsp"
-version = "0.1.0"
+version = "0.3.0"
 edition = "2024"
 authors = ["mochi"]
 description = "Language Server Protocol implementation for AngularJS 1.x"

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Change Log
 
+## [0.3.0] - 2026-04-30
+
+### Breaking changes
+- `ajsconfig.json` の `interpolate.startSymbol` / `interpolate.endSymbol` 設定を撤去。interpolate 記号は AngularJS ソース中の `$interpolateProvider.startSymbol(...)` / `.endSymbol(...)` 呼び出しから自動検出されるようになった。配列 DI rename / 暗黙 DI / チェイン呼び出しすべて対応。古い ajsconfig.json に `interpolate` フィールドが残っていてもパースエラーにはならず黙って無視される
+
+### Features
+- `$interpolateProvider` カスタム記号を JS ソースから自動検出 (PR #34)
+- `InterpolateStore` を cache に持続化、cache hit 起動でも custom 記号を維持
+
+### Fixes
+- `$routeProvider` / `$stateProvider` の receiver 検証を追加し、無関係な `obj.when()` / `obj.state()` を route binding として誤検知しないように (PR #33)
+- HTML 補完で `$scope.X` (Method) と `X` (Function) が重複して出る問題を修正 (PR #26)
+- `pending_reanalysis` の取りこぼし & 孫漏れを drain ループ + visited セットで解消 (PR #31)
+
+### Performance
+- 全 LSP リクエストハンドラを `spawn_blocking` で隔離し、tokio worker 占有を解消 (PR #35)
+- `find_symbol_at_position` を URI 逆引きで O(該当URI) 化 — hover/refs/rename/定義ジャンプを高速化 (PR #36)
+- `get_reference_names_for_uri` を URI 逆引きで O(該当URI) 化 — HTML edit 時の snapshot 計算を高速化 (PR #37)
+- 定義取得を `document_symbols` URI 逆引きで O(該当ファイル) 化 (PR #25)
+- HTML 変更時の JS 再診断を依存関係に基づいて絞り込み (PR #27)
+- シンボル参照アクセスを borrowing API に置換し Vec clone を回避 (PR #28)
+- 不要な `semantic_tokens_refresh` / `code_lens_refresh` をスキップ — cross-file dep snapshot で gate (PR #29 / #30)
+- tsserver の `did_change` を debounce + 必要時 flush (PR #32)
+
 ## [0.1.0] - Initial Release
 
 ### Added

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "angularjs-lsp",
-  "version": "0.2.14",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "angularjs-lsp",
-      "version": "0.2.14",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "angularjs-lsp",
   "displayName": "AngularJS 1.x IntelliSense",
   "description": "Language Server Protocol implementation for AngularJS 1.x projects",
-  "version": "0.2.19",
+  "version": "0.3.0",
   "icon": "icon.png",
   "publisher": "mochi33",
   "license": "MIT",


### PR DESCRIPTION
## Summary

v0.2.19 以降の **11 PR** をまとめて v0.3.0 としてリリースする準備。

## バージョンバンプ

| ファイル | 変更 |
|---|---|
| \`vscode-extension/package.json\` | 0.2.19 → 0.3.0 |
| \`Cargo.toml\` | 0.1.0 → 0.3.0 (alignment) |
| \`vscode-extension/CHANGELOG.md\` | v0.3.0 エントリ追加 |

## CI 変更

\`.github/workflows/release.yml\` に Open VSX publish step を追加:

\`\`\`yaml
- name: Publish to Open VSX
  if: env.OVSX_PAT != ''
  working-directory: vscode-extension
  run: npx ovsx publish *.vsix -p \"\$OVSX_PAT\"

- name: Skip Open VSX publish (no OVSX_PAT secret)
  if: env.OVSX_PAT == ''
  run: echo \"::warning::OVSX_PAT secret not set, skipping Open VSX publish.\"
\`\`\`

\`OVSX_PAT\` secret が設定されていれば自動 publish、未設定なら warning 出して skip する gate 付き。

## v0.3.0 の主な内容

### Breaking
- \`ajsconfig.json\` の \`interpolate.*\` 設定を撤去 (PR #34)
  - 旧設定は serde が黙って無視 (パースエラーなし)
  - 代替: AngularJS ソースの \`\$interpolateProvider.startSymbol/endSymbol\` から自動検出

### Features
- \`\$interpolateProvider\` カスタム interpolate 記号の自動検出 (PR #34)
- InterpolateStore を cache に永続化

### Fixes
- \`\$routeProvider\` / \`\$stateProvider\` receiver 検証で誤検知防止 (PR #33)
- HTML 補完の重複候補修正 (PR #26)
- \`pending_reanalysis\` の取りこぼし & 孫漏れ解消 (PR #31)

### Performance
- 全 LSP ハンドラを spawn_blocking で隔離 (PR #35)
- \`find_symbol_at_position\` / \`get_reference_names_for_uri\` を URI 逆引き化 (PR #36, #37)
- 定義取得 O(該当ファイル) 化 (PR #25)
- HTML→JS 再診断のピンポイント化 (PR #27)
- borrowing API による Vec clone 回避 (PR #28)
- refresh signals の cross-file dep gate (PR #29, #30)
- tsserver did_change の debounce (PR #32)

## マージ後の手順

1. このブランチを master にマージ
2. 以下を実行してタグをプッシュ:
   \`\`\`
   git fetch origin master
   git checkout master && git pull
   git tag v0.3.0
   git push origin v0.3.0
   \`\`\`
3. CI が動作:
   - 5 platform 分のバイナリビルド
   - GitHub Release 作成 (バイナリ + VSIX 添付)
   - \`OVSX_PAT\` 設定済なら Open VSX へ自動 publish

## OVSX_PAT が未設定の場合

リポジトリの GitHub Actions secrets に \`OVSX_PAT\` を追加する必要あり:

\`\`\`
gh secret set OVSX_PAT
# (token を貼り付け)
\`\`\`

Open VSX のトークンは https://open-vsx.org/user-settings/tokens で発行。

または手動 publish:

\`\`\`
# release が出来たら VSIX を取得して
npx ovsx publish vscode-extension/angularjs-lsp-0.3.0.vsix -p \$OVSX_PAT
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)