### PR TITLE
chore: release v0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "angularjs-lsp"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bincode",
  "dashmap 6.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "angularjs-lsp"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 authors = ["mochi"]
 description = "Language Server Protocol implementation for AngularJS 1.x"

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [0.3.1] - 2026-04-30
+
+### Fixes
+- LSP 起動時に既に開かれていた HTML/JS ファイルが、新規ファイルを開くまで解析されない問題を修正 (PR #39)
+  - `initialized()` の workspace scan 完了後に `republish_open_files_after_init` を実行し、(a) 開いている全ファイルを buffer 内容で再解析、(b) 全 open file の診断を再発行 (HTML + JS)、(c) `semantic_tokens_refresh` / `code_lens_refresh` を発火
+  - 旧来は scan_workspace が disk 内容で開いているファイルを上書きしてしまうレースと、HTML 診断 / refresh signal の取りこぼしが重なり、新規ファイル open まで解析が走らないように見える症状があった
+
 ## [0.3.0] - 2026-04-30
 
 ### Breaking changes

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "angularjs-lsp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "angularjs-lsp",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "angularjs-lsp",
   "displayName": "AngularJS 1.x IntelliSense",
   "description": "Language Server Protocol implementation for AngularJS 1.x projects",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "icon": "icon.png",
   "publisher": "mochi33",
   "license": "MIT",


### PR DESCRIPTION
## Summary

PR #39 のフィックスを v0.3.1 として release する準備。

## バージョンバンプ

| ファイル | 変更 |
|---|---|
| \`vscode-extension/package.json\` | 0.3.0 → 0.3.1 |
| \`Cargo.toml\` | 0.3.0 → 0.3.1 |
| \`vscode-extension/CHANGELOG.md\` | v0.3.1 エントリ追加 |

## 主な修正

### Fix: LSP 起動時に既に開かれていた HTML/JS ファイルが、新規ファイルを開くまで解析されない問題 (PR #39)

\`initialized()\` の workspace scan 完了後に \`republish_open_files_after_init\` を実行し、(a) 開いている全ファイルを buffer 内容で再解析、(b) 全 open file の診断を再発行 (HTML + JS)、(c) \`semantic_tokens_refresh\` / \`code_lens_refresh\` を発火するようにした。

## マージ後

\`\`\`bash
git fetch origin master
git checkout master && git pull
git tag v0.3.1
git push origin v0.3.1
\`\`\`

CI が以下を実行:
- 5 platform 分のバイナリビルド
- GitHub Release 作成 (バイナリ + VSIX 添付)
- Open VSX 自動 publish (\`OVSX_PAT\` 設定済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)