### PR TITLE
feat: $stateProvider の名前付きビュー (views) に対応

### DIFF
--- a/UNSUPPORTED_FEATURES.md
+++ b/UNSUPPORTED_FEATURES.md
@@ -47,22 +47,22 @@ angular.module('app', []).factory('UserResource', ['$resource', function($resour
 
 ---
 
-### 4. `$stateProvider.state()` (ui-router) のコントローラー参照が追跡されない
+### ~~4. `$stateProvider.state()` (ui-router) のコントローラー参照が追跡されない~~ (対応済み)
 
-`$routeProvider.when()` は対応済みだが、ui-router の `$stateProvider.state()` は未対応。
+`$stateProvider.state()` の `controller` / `templateUrl` の抽出、チェーン記法、配列 DI でリネームされた
+レシーバ、トップレベル呼び出し、インライン controller 関数、`views: { ... }` 名前付きビュー
+すべて対応済み。
 
 ```javascript
-angular.module('app', []).config(['$stateProvider', function($stateProvider) {
-    $stateProvider
-        .state('home', {
-            url: '/home',
-            templateUrl: 'views/home.html',
-            controller: 'HomeController'   // 参照として追跡されない
-        });
-}]);
+$stateProvider.state('layout', {
+    views: {
+        'main':    { templateUrl: 'main.html',    controller: 'MainController' },     // ✓ 参照登録
+        'sidebar': { templateUrl: 'sidebar.html', controller: 'SidebarController' }   // ✓ 参照登録
+    }
+});
 ```
 
-**対応案**: `$stateProvider.state()` の第2引数オブジェクトから `controller` と `templateUrl` を抽出し、テンプレートバインディングとして登録する。
+**未対応**: `resolve: { ... }` の依存注入、`ui-sref` / `ui-view` HTML 属性、`$state.go()` / `$state.transitionTo()` JS 参照、dot-notation 親子 state の階層追跡。
 
 ---
 

--- a/src/analyzer/js/component.rs
+++ b/src/analyzer/js/component.rs
@@ -546,6 +546,9 @@ impl AngularJsAnalyzer {
 
     /// $stateProvider.state() の設定オブジェクトからcontrollerプロパティを探し、DIスコープを抽出する
     /// また、controller と templateUrl の組み合わせでテンプレートバインディングも登録する
+    ///
+    /// `views: { 'main': {...}, 'sidebar': {...} }` (ui-router の名前付きビュー) も
+    /// 各ビュー設定を再帰的に処理する。
     fn extract_controller_di_from_state_config(&self, obj_node: Node, source: &str, uri: &Url, ctx: &mut AnalyzerContext) {
         // テンプレートバインディング用にcontrollerとtemplateUrlを収集（StateProviderソース）
         self.extract_template_binding_from_object(obj_node, source, uri, BindingSource::StateProvider);
@@ -606,6 +609,28 @@ impl AngularJsAnalyzer {
                                 }
                             }
                         }
+                    } else if key_name == "views" {
+                        // ui-router 名前付きビュー: views: { 'main': {...}, 'sidebar': {...} }
+                        // 各ビュー設定は state 設定と同じ controller / templateUrl 構造を持つ
+                        if let Some(views_obj) = child.child_by_field_name("value") {
+                            if views_obj.kind() == "object" {
+                                self.extract_state_views(views_obj, source, uri, ctx);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// `views: { 'name': { controller, templateUrl, ... }, ... }` の各ビュー設定を処理する
+    fn extract_state_views(&self, views_obj: Node, source: &str, uri: &Url, ctx: &mut AnalyzerContext) {
+        let mut cursor = views_obj.walk();
+        for child in views_obj.children(&mut cursor) {
+            if child.kind() == "pair" {
+                if let Some(value) = child.child_by_field_name("value") {
+                    if value.kind() == "object" {
+                        self.extract_controller_di_from_state_config(value, source, uri, ctx);
                     }
                 }
             }

--- a/tests/angularjs_common_syntax_test.rs
+++ b/tests/angularjs_common_syntax_test.rs
@@ -1643,6 +1643,119 @@ angular.module('app', []).config(['$stateProvider', function($stateProvider) {
         "3つのテンプレートバインディングが登録されるべき");
 }
 
+#[test]
+fn test_state_provider_named_views_controller_references() {
+    // ui-router 名前付きビュー: views: { 'name': { controller, templateUrl } }
+    let source = r#"
+angular.module('app', []).config(['$stateProvider', function($stateProvider) {
+    $stateProvider.state('layout', {
+        url: '/layout',
+        views: {
+            'main': {
+                templateUrl: 'views/main.html',
+                controller: 'MainViewController'
+            },
+            'sidebar': {
+                templateUrl: 'views/sidebar.html',
+                controller: 'SidebarController'
+            }
+        }
+    });
+}]);
+"#;
+    let index = analyze_js(source);
+    assert!(has_reference(&index, "MainViewController"),
+        "named view 'main' の controller 参照が認識されるべき");
+    assert!(has_reference(&index, "SidebarController"),
+        "named view 'sidebar' の controller 参照が認識されるべき");
+}
+
+#[test]
+fn test_state_provider_named_views_template_bindings() {
+    let source = r#"
+angular.module('app', []).config(['$stateProvider', function($stateProvider) {
+    $stateProvider.state('dashboard', {
+        url: '/dashboard',
+        views: {
+            'header': {
+                templateUrl: 'views/header.html',
+                controller: 'HeaderController'
+            },
+            'content': {
+                templateUrl: 'views/content.html',
+                controller: 'ContentController'
+            }
+        }
+    });
+}]);
+"#;
+    let index = analyze_js(source);
+    let bindings = index.templates.get_all_template_bindings();
+    let has_header = bindings.iter().any(|b|
+        b.template_path.contains("header.html") && b.controller_name == "HeaderController"
+    );
+    let has_content = bindings.iter().any(|b|
+        b.template_path.contains("content.html") && b.controller_name == "ContentController"
+    );
+    assert!(has_header,
+        "named view 'header' のテンプレートバインディングが登録されるべき");
+    assert!(has_content,
+        "named view 'content' のテンプレートバインディングが登録されるべき");
+}
+
+#[test]
+fn test_state_provider_named_views_inline_controller() {
+    // 名前付きビュー内のインライン controller の DI スコープが認識される
+    let source = r#"
+angular.module('app', []).config(['$stateProvider', function($stateProvider) {
+    $stateProvider.state('split', {
+        url: '/split',
+        views: {
+            'top': {
+                templateUrl: 'views/top.html',
+                controller: ['$scope', function($scope) {
+                    $scope.topItem = 1;
+                }]
+            }
+        }
+    });
+}]);
+"#;
+    let index = analyze_js(source);
+    assert!(has_definition(&index, "state.$scope.topItem", SymbolKind::ScopeProperty),
+        "named view 内のインライン controller の $scope プロパティが認識されるべき");
+}
+
+#[test]
+fn test_state_provider_top_level_and_named_views_coexist() {
+    // 親 state に templateUrl/controller がありつつ views も持つケース
+    // (両方とも binding として登録される)
+    let source = r#"
+angular.module('app', []).config(['$stateProvider', function($stateProvider) {
+    $stateProvider.state('parent', {
+        url: '/parent',
+        templateUrl: 'views/parent.html',
+        controller: 'ParentController',
+        views: {
+            'child': {
+                templateUrl: 'views/child.html',
+                controller: 'ChildController'
+            }
+        }
+    });
+}]);
+"#;
+    let index = analyze_js(source);
+    assert!(has_reference(&index, "ParentController"),
+        "親 state の controller 参照が認識されるべき");
+    assert!(has_reference(&index, "ChildController"),
+        "named view 内の controller 参照も認識されるべき");
+
+    let bindings = index.templates.get_all_template_bindings();
+    assert_eq!(bindings.len(), 2,
+        "親と named view の両方のテンプレートバインディングが登録されるべき");
+}
+
 // ============================================================
 // workspace/symbol テスト
 // ============================================================


### PR DESCRIPTION
## Summary

ui-router の `$stateProvider.state('name', { views: {...} })` で定義される
名前付きビューの controller / templateUrl を解析対象に追加。

```javascript
$stateProvider.state('layout', {
    views: {
        'main':    { templateUrl: 'main.html',    controller: 'MainController' },
        'sidebar': { templateUrl: 'sidebar.html', controller: 'SidebarController' }
    }
});
```

これまで親 state の top-level `controller` / `templateUrl` のみを解析していたため、
`views` 内の controller 参照や template binding が見落とされていた。今回のパッチで:

- `controller: 'Foo'` の文字列参照 → Reference として登録 (定義ジャンプ可能に)
- `controller: function/array` → DI スコープを構築 (`$scope.X` 解析が動く)
- `templateUrl` + `controller` → TemplateBinding として登録 (CodeLens / 双方向ジャンプ)
- 親 state の templateUrl/controller と views を併存させた場合も両方登録

実装は `extract_controller_di_from_state_config` に `views` キー検出を追加し、
各ビュー設定オブジェクトを再帰的に同関数に渡すだけのシンプルな変更。

`UNSUPPORTED_FEATURES.md` の項目4 を「対応済み」に更新し、未対応の
ui-router 機能 (`resolve`, `ui-sref`, `ui-view`, `\$state.go`) を明記。

## Test plan

- [x] `cargo test` 全件通過 (lib 161 + integration 134)
- [x] 新規テスト 4 件 (`test_state_provider_named_views_*`) 通過
- [x] `cargo clippy --lib --tests` で新規 warning なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)