### PR TITLE
feat: ui-sref / $state.go の state 名参照を追跡

### DIFF
--- a/UNSUPPORTED_FEATURES.md
+++ b/UNSUPPORTED_FEATURES.md
@@ -62,7 +62,13 @@ $stateProvider.state('layout', {
 });
 ```
 
-**未対応**: `resolve: { ... }` の依存注入、`ui-sref` / `ui-view` HTML 属性、`$state.go()` / `$state.transitionTo()` JS 参照、dot-notation 親子 state の階層追跡。
+追加対応:
+- `$stateProvider.state('home', ...)` で state 名が `SymbolKind::UiRouterState` として登録される
+- `$state.go('home')` / `$state.transitionTo('home')` の state 名参照を追跡 (DI rename も対応)
+- `ui-sref="home"` / `ui-sref="home({id: 1})"` / `ui-sref="users.detail"` の state 名参照を追跡
+- ui-sref → state 定義への goto-definition / hover, find-references で HTML/JS 横断列挙
+
+**未対応**: `resolve: { ... }` の依存注入、`ui-view` named view 属性、ui-router の相対 state 参照 (`.`, `^`, `^.foo`)、`ui-state="..."` 動的 state 名属性、dot-notation 親子 state の階層追跡。
 
 ---
 

--- a/src/analyzer/html/scope_reference.rs
+++ b/src/analyzer/html/scope_reference.rs
@@ -4,7 +4,7 @@ use tower_lsp::lsp_types::Url;
 use tree_sitter::Node;
 
 use super::directives::{is_directive_attribute, is_literal_value_directive};
-use crate::model::{HtmlNgModelTarget, HtmlScopeReference};
+use crate::model::{HtmlNgModelTarget, HtmlScopeReference, HtmlUiSrefReference, Span, SymbolReference};
 
 use super::HtmlAngularJsAnalyzer;
 
@@ -57,6 +57,18 @@ impl HtmlAngularJsAnalyzer {
                         let value_start_line = value_node.start_position().row as usize;
                         let value_byte_col = value_node.start_position().column + 1; // +1 for quote
                         let value_start_col = self.byte_col_to_utf16_col(source, value_start_line, value_byte_col);
+
+                        // ui-router の `ui-sref="state[(...args)]"` は
+                        // ディレクティブとしての扱いとは別に state 名参照として登録する。
+                        // (`ui-sref-active` / `ui-sref-active-eq` は CSS class なので除外)
+                        if matches!(attr_name.as_str(), "ui-sref" | "data-ui-sref") {
+                            self.register_ui_sref_reference(
+                                uri,
+                                value,
+                                value_start_line as u32,
+                                value_start_col,
+                            );
+                        }
 
                         if is_directive_attribute(
                             &attr_name,
@@ -166,6 +178,62 @@ impl HtmlAngularJsAnalyzer {
                 self.index.html.add_html_scope_reference(html_reference);
             }
         }
+    }
+
+    /// `ui-sref="state-name[(...args)]"` の state 名部分を `HtmlUiSrefReference` と
+    /// `SymbolReference` の両方として登録する。
+    ///
+    /// 値の形式:
+    /// - `home` → state 名 = "home"
+    /// - `home.detail` → state 名 = "home.detail" (dot-notation 子 state)
+    /// - `home({id: 1})` → state 名 = "home" (引数部分は無視)
+    ///
+    /// 以下はスキップ:
+    /// - 空文字列
+    /// - 相対参照 (`.`, `^`, `^.foo` など) — state 名解決に親 state コンテキストが必要
+    fn register_ui_sref_reference(
+        &self,
+        uri: &Url,
+        value: &str,
+        value_start_line: u32,
+        value_start_col: u32,
+    ) {
+        // 引数部分 `(...)` の前までを state 名として切り出す
+        let name_part = value.split('(').next().unwrap_or(value);
+        let trimmed = name_part.trim();
+        if trimmed.is_empty() {
+            return;
+        }
+
+        // ui-router の相対参照は今は解決対象外
+        if trimmed == "." || trimmed.starts_with('^') {
+            return;
+        }
+
+        // 先頭の空白文字数だけ start_col をずらす
+        let leading_whitespace_bytes = name_part.len() - name_part.trim_start().len();
+        let utf16_leading = self.byte_offset_to_utf16_offset(name_part, leading_whitespace_bytes) as u32;
+        let start_col = value_start_col + utf16_leading;
+        let len_utf16 = trimmed.chars().map(|c| c.len_utf16()).sum::<usize>() as u32;
+        let end_col = start_col + len_utf16;
+
+        let reference = HtmlUiSrefReference {
+            state_name: trimmed.to_string(),
+            uri: uri.clone(),
+            start_line: value_start_line,
+            start_col,
+            end_line: value_start_line,
+            end_col,
+        };
+        self.index.html.add_ui_sref_reference(reference);
+
+        // 既存の find-references インフラ用に SymbolReference も登録する
+        // (これにより state 定義からの find-references で HTML 側の使用箇所も列挙される)
+        self.index.definitions.add_reference(SymbolReference {
+            name: trimmed.to_string(),
+            uri: uri.clone(),
+            span: Span::new(value_start_line, start_col, value_start_line, end_col),
+        });
     }
 
     /// 属性値内のインターポレーションからスコープ参照を抽出（UTF-16対応）

--- a/src/analyzer/js/component.rs
+++ b/src/analyzer/js/component.rs
@@ -85,6 +85,14 @@ impl AngularJsAnalyzer {
                                 self.extract_state_provider_di(node, source, uri, ctx);
                             }
                         }
+                        "go" | "transitionTo" => {
+                            // `$state.go('home')` / `$state.transitionTo('home')` の
+                            // 第1引数 (state 名) を参照として登録する。
+                            // `$state` であることを厳密に判定して誤検知を避ける。
+                            if self.is_state_service_receiver(callee, source, ctx) {
+                                self.extract_state_navigation_reference(node, source, uri);
+                            }
+                        }
                         _ => {}
                     }
                 }
@@ -523,7 +531,7 @@ impl AngularJsAnalyzer {
         }
     }
 
-    /// `$stateProvider.state()` (ui-router) のcontrollerプロパティからDIスコープを抽出する
+    /// `$stateProvider.state()` (ui-router) の state 定義と controller DI スコープを抽出する
     ///
     /// 認識パターン:
     /// ```javascript
@@ -533,8 +541,36 @@ impl AngularJsAnalyzer {
     ///     controller: 'HomeController'
     /// })
     /// ```
+    ///
+    /// 第1引数の文字列を `SymbolKind::UiRouterState` として登録し、
+    /// `ui-sref="home"` や `$state.go('home')` からのジャンプを可能にする。
     fn extract_state_provider_di(&self, node: Node, source: &str, uri: &Url, ctx: &mut AnalyzerContext) {
         if let Some(args) = node.child_by_field_name("arguments") {
+            // state('name', ...) の第1引数は state 名 (文字列リテラル)
+            if let Some(name_arg) = args.named_child(0) {
+                if name_arg.kind() == "string" {
+                    let state_name = self.extract_string_value(name_arg, source);
+                    let start = name_arg.start_position();
+                    let end = name_arg.end_position();
+                    let span = Span::new(
+                        self.offset_line(start.row as u32),
+                        start.column as u32,
+                        self.offset_line(end.row as u32),
+                        end.column as u32,
+                    );
+
+                    let symbol = SymbolBuilder::new(
+                        state_name,
+                        SymbolKind::UiRouterState,
+                        uri.clone(),
+                    )
+                    .definition_span(span)
+                    .name_span(span)
+                    .build();
+                    self.index.definitions.add_definition(symbol);
+                }
+            }
+
             // state('name', {config}) の設定オブジェクトは第2引数
             if let Some(config_obj) = args.named_child(1) {
                 if config_obj.kind() == "object" {
@@ -542,6 +578,71 @@ impl AngularJsAnalyzer {
                 }
             }
         }
+    }
+
+    /// `$state.go('home')` / `$state.transitionTo('home')` のレシーバが
+    /// `$state` (またはそれに DI されたローカル変数) かを判定する。
+    ///
+    /// `is_provider_receiver` と異なり `state` 単体は許容しない (一般変数名と紛らわしいため)。
+    /// `$state` を直接含む形式 (`$state`, `this.$state` など) のみ true。
+    fn is_state_service_receiver(
+        &self,
+        callee: Node,
+        source: &str,
+        ctx: &AnalyzerContext,
+    ) -> bool {
+        let object = match callee.child_by_field_name("object") {
+            Some(o) => o,
+            None => return false,
+        };
+        let root = Self::unwrap_chain_receiver(object);
+        let root_text = self.node_text(root, source);
+
+        // 1. `$state` を含むレシーバ
+        if root_text == "$state" || root_text.ends_with(".$state") {
+            return true;
+        }
+
+        // 2. 単純識別子なら DI 経由でリネームされたケースをチェック
+        if root.kind() == "identifier" {
+            let line = self.offset_line(callee.start_position().row as u32);
+            if let Some(service) = ctx.resolve_di_param(&root_text, line) {
+                return service == "$state";
+            }
+        }
+
+        false
+    }
+
+    /// `$state.go('home')` / `$state.transitionTo('home')` の第1引数 (state 名) を
+    /// `SymbolReference` として登録する。
+    ///
+    /// 文字列リテラル以外 (動的式) は state 名を解決できないので無視する。
+    fn extract_state_navigation_reference(&self, node: Node, source: &str, uri: &Url) {
+        let args = match node.child_by_field_name("arguments") {
+            Some(a) => a,
+            None => return,
+        };
+        let first_arg = match args.named_child(0) {
+            Some(a) => a,
+            None => return,
+        };
+        if first_arg.kind() != "string" {
+            return;
+        }
+        let state_name = self.extract_string_value(first_arg, source);
+        let start = first_arg.start_position();
+        let end = first_arg.end_position();
+        self.index.definitions.add_reference(SymbolReference {
+            name: state_name,
+            uri: uri.clone(),
+            span: Span::new(
+                self.offset_line(start.row as u32),
+                start.column as u32,
+                self.offset_line(end.row as u32),
+                end.column as u32,
+            ),
+        });
     }
 
     /// $stateProvider.state() の設定オブジェクトからcontrollerプロパティを探し、DIスコープを抽出する

--- a/src/handler/completion.rs
+++ b/src/handler/completion.rs
@@ -573,6 +573,7 @@ impl CompletionHandler {
             SymbolKind::FormBinding => CompletionItemKind::VARIABLE,
             SymbolKind::ExportedComponent => CompletionItemKind::CLASS,
             SymbolKind::ComponentBinding => CompletionItemKind::PROPERTY,
+            SymbolKind::UiRouterState => CompletionItemKind::EVENT,
         }
     }
 }

--- a/src/handler/definition.rs
+++ b/src/handler/definition.rs
@@ -63,7 +63,33 @@ impl DefinitionHandler {
         position: Position,
         source: Option<&str>,
     ) -> Option<GotoDefinitionResponse> {
-        // 0. まずカスタムディレクティブ/コンポーネント参照をチェック
+        // 0. ui-router の `ui-sref="state"` 参照を最優先でチェック
+        if let Some(ui_sref) = self
+            .index
+            .html
+            .find_ui_sref_reference_at(uri, position.line, position.character)
+        {
+            let definitions = self.index.definitions.get_definitions(&ui_sref.state_name);
+            let state_defs: Vec<_> = definitions
+                .into_iter()
+                .filter(|d| d.kind == SymbolKind::UiRouterState)
+                .collect();
+            if !state_defs.is_empty() {
+                let locations: Vec<Location> = state_defs
+                    .into_iter()
+                    .map(|def| Location {
+                        uri: def.uri.clone(),
+                        range: def.name_span.to_lsp_range(),
+                    })
+                    .collect();
+                return Some(GotoDefinitionResponse::Array(locations));
+            }
+            // state 定義が見つからなくても、他のシンボルとして解決すべきではない
+            // (ui-sref の値は state 名なので、controller 名等として解決すると誤動作する)
+            return None;
+        }
+
+        // 0b. まずカスタムディレクティブ/コンポーネント参照をチェック
         if let Some(directive_ref) =
             self.index
                 .html

--- a/src/handler/hover.rs
+++ b/src/handler/hover.rs
@@ -5,7 +5,7 @@ use tower_lsp::lsp_types::*;
 use crate::index::Index;
 use crate::model::{
     DirectiveUsageType, HtmlDirectiveReference, HtmlFormBinding, HtmlLocalVariable,
-    HtmlLocalVariableSource, HtmlNgModelTarget,
+    HtmlLocalVariableSource, HtmlNgModelTarget, SymbolKind,
 };
 use crate::util::is_html_file;
 
@@ -38,6 +38,22 @@ impl HoverHandler {
 
     /// HTMLファイルからのホバー
     fn hover_from_html(&self, uri: &Url, position: Position) -> Option<Hover> {
+        // 0. ui-router の `ui-sref="state"` を最優先でチェック
+        if let Some(ui_sref) = self
+            .index
+            .html
+            .find_ui_sref_reference_at(uri, position.line, position.character)
+        {
+            let definitions = self.index.definitions.get_definitions(&ui_sref.state_name);
+            let state_def = definitions
+                .into_iter()
+                .find(|d| d.kind == SymbolKind::UiRouterState);
+            if let Some(def) = state_def {
+                return self.build_hover_for_symbol(&def.name);
+            }
+            return None;
+        }
+
         // 1. まずローカル変数をチェック（定義位置にカーソルがある場合）
         if let Some(local_var_def) = self.index.html.find_html_local_variable_definition_at(
             uri,

--- a/src/handler/references.rs
+++ b/src/handler/references.rs
@@ -51,7 +51,16 @@ impl ReferencesHandler {
         position: Position,
         include_declaration: bool,
     ) -> Option<Vec<Location>> {
-        // 0. まずカスタムディレクティブ参照をチェック
+        // 0. ui-router の `ui-sref="state"` 参照を最優先でチェック
+        if let Some(ui_sref) = self
+            .index
+            .html
+            .find_ui_sref_reference_at(uri, position.line, position.character)
+        {
+            return self.collect_state_references(&ui_sref.state_name, include_declaration);
+        }
+
+        // 0b. カスタムディレクティブ参照をチェック
         if let Some(directive_ref) = self.index.html.find_html_directive_reference_at(
             uri,
             position.line,
@@ -232,6 +241,39 @@ impl ReferencesHandler {
         }
 
         None
+    }
+
+    /// ui-router state 名の定義 (UiRouterState kind) と全参照を収集
+    fn collect_state_references(
+        &self,
+        state_name: &str,
+        include_declaration: bool,
+    ) -> Option<Vec<Location>> {
+        let mut locations = Vec::new();
+
+        if include_declaration {
+            for def in self.index.definitions.get_definitions(state_name) {
+                if def.kind == SymbolKind::UiRouterState {
+                    locations.push(Location {
+                        uri: def.uri.clone(),
+                        range: def.definition_span.to_lsp_range(),
+                    });
+                }
+            }
+        }
+
+        for reference in self.index.definitions.get_references(state_name) {
+            locations.push(Location {
+                uri: reference.uri.clone(),
+                range: reference.span.to_lsp_range(),
+            });
+        }
+
+        if locations.is_empty() {
+            None
+        } else {
+            Some(locations)
+        }
     }
 
     /// シンボル名から定義と参照を収集

--- a/src/index/html_store.rs
+++ b/src/index/html_store.rs
@@ -3,7 +3,7 @@ use tower_lsp::lsp_types::Url;
 
 use crate::model::{
     HtmlDirectiveReference, HtmlFormBinding, HtmlLocalVariable, HtmlLocalVariableReference,
-    HtmlNgModelTarget, HtmlScopeReference,
+    HtmlNgModelTarget, HtmlScopeReference, HtmlUiSrefReference,
 };
 
 /// HTMLスコープ参照・ローカル変数・フォーム・ディレクティブの管理ストア
@@ -23,6 +23,9 @@ pub struct HtmlStore {
     /// ng-model がバインドする箇所があれば暗黙的に scope に存在するとみなす
     /// (診断の false positive 抑制用)
     ng_model_targets: DashMap<Url, Vec<HtmlNgModelTarget>>,
+    /// HTML 内の ui-router `ui-sref="state"` 参照 (URI -> Vec<HtmlUiSrefReference>)
+    /// state 名 → state 定義へのジャンプ・ホバー解決に使う
+    ui_sref_references: DashMap<Url, Vec<HtmlUiSrefReference>>,
 }
 
 impl HtmlStore {
@@ -34,6 +37,7 @@ impl HtmlStore {
             html_form_bindings: DashMap::new(),
             html_directive_references: DashMap::new(),
             ng_model_targets: DashMap::new(),
+            ui_sref_references: DashMap::new(),
         }
     }
 
@@ -423,6 +427,60 @@ impl HtmlStore {
             .collect()
     }
 
+    // ========== ui-sref ==========
+
+    pub fn add_ui_sref_reference(&self, reference: HtmlUiSrefReference) {
+        let uri = reference.uri.clone();
+        self.ui_sref_references
+            .entry(uri)
+            .or_default()
+            .push(reference);
+    }
+
+    pub fn find_ui_sref_reference_at(
+        &self,
+        uri: &Url,
+        line: u32,
+        col: u32,
+    ) -> Option<HtmlUiSrefReference> {
+        if let Some(refs) = self.ui_sref_references.get(uri) {
+            for r in refs.iter() {
+                if r.span().contains(line, col) {
+                    return Some(r.clone());
+                }
+            }
+        }
+        None
+    }
+
+    pub fn get_ui_sref_references_for_uri(&self, uri: &Url) -> Vec<HtmlUiSrefReference> {
+        self.ui_sref_references
+            .get(uri)
+            .map(|v| v.value().clone())
+            .unwrap_or_default()
+    }
+
+    /// 指定 state 名にマッチする全 ui-sref 参照を返す
+    pub fn get_ui_sref_references_by_state(&self, state_name: &str) -> Vec<HtmlUiSrefReference> {
+        let mut result = Vec::new();
+        for entry in self.ui_sref_references.iter() {
+            for r in entry.value().iter() {
+                if r.state_name == state_name {
+                    result.push(r.clone());
+                }
+            }
+        }
+        result
+    }
+
+    /// 全 ui-sref 参照を取得 (キャッシュ用)
+    pub fn get_all_ui_sref_references_for_cache(&self) -> Vec<HtmlUiSrefReference> {
+        self.ui_sref_references
+            .iter()
+            .flat_map(|entry| entry.value().clone())
+            .collect()
+    }
+
     // ========== クリア ==========
 
     /// HTML参照情報のみをクリア（Pass 3で収集する情報）
@@ -434,6 +492,7 @@ impl HtmlStore {
         }
         self.html_directive_references.remove(uri);
         self.ng_model_targets.remove(uri);
+        self.ui_sref_references.remove(uri);
     }
 
     pub fn clear_document(&self, uri: &Url) {
@@ -445,6 +504,7 @@ impl HtmlStore {
         self.html_form_bindings.remove(uri);
         self.html_directive_references.remove(uri);
         self.ng_model_targets.remove(uri);
+        self.ui_sref_references.remove(uri);
     }
 
     pub fn clear_all(&self) {
@@ -454,6 +514,7 @@ impl HtmlStore {
         self.html_form_bindings.clear();
         self.html_directive_references.clear();
         self.ng_model_targets.clear();
+        self.ui_sref_references.clear();
     }
 }
 

--- a/src/model/html.rs
+++ b/src/model/html.rs
@@ -207,3 +207,24 @@ impl HtmlDirectiveReference {
         Span::new(self.start_line, self.start_col, self.end_line, self.end_col)
     }
 }
+
+/// `ui-sref="home"` / `ui-sref="home.detail({id: 1})"` などで参照される
+/// ui-router state 名と、それが属性値として書かれているHTML上の位置範囲を表す。
+///
+/// `state_name` は `(` の前までを切り出した state 名のみ。
+/// `start_*` / `end_*` はその state 名部分の位置 (引数部分は含まない)。
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct HtmlUiSrefReference {
+    pub state_name: String,
+    pub uri: Url,
+    pub start_line: u32,
+    pub start_col: u32,
+    pub end_line: u32,
+    pub end_col: u32,
+}
+
+impl HtmlUiSrefReference {
+    pub fn span(&self) -> Span {
+        Span::new(self.start_line, self.start_col, self.end_line, self.end_col)
+    }
+}

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -12,7 +12,7 @@ pub use export::{ExportInfo, ExportedComponentObject};
 pub use html::{
     DirectiveUsageType, HtmlDirectiveReference, HtmlFormBinding, HtmlLocalVariable,
     HtmlLocalVariableReference, HtmlLocalVariableSource, HtmlNgModelTarget, HtmlScopeReference,
-    InheritedFormBinding, InheritedLocalVariable,
+    HtmlUiSrefReference, InheritedFormBinding, InheritedLocalVariable,
 };
 pub use inheritance::{NgIncludeBinding, NgViewBinding};
 pub use scope::{ControllerScope, HtmlControllerScope};

--- a/src/model/symbol.rs
+++ b/src/model/symbol.rs
@@ -31,6 +31,8 @@ pub enum SymbolKind {
     ExportedComponent,
     /// コンポーネントのbindingsプロパティ（'<', '=', '@', '&'）
     ComponentBinding,
+    /// ui-router の state ($stateProvider.state('name', ...) で登録される名前)
+    UiRouterState,
 }
 
 impl SymbolKind {
@@ -54,6 +56,7 @@ impl SymbolKind {
             SymbolKind::FormBinding => "form binding",
             SymbolKind::ExportedComponent => "exported component",
             SymbolKind::ComponentBinding => "component binding",
+            SymbolKind::UiRouterState => "ui-router state",
         }
     }
 
@@ -77,6 +80,7 @@ impl SymbolKind {
             SymbolKind::FormBinding => lsp_types::SymbolKind::VARIABLE,
             SymbolKind::ExportedComponent => lsp_types::SymbolKind::CLASS,
             SymbolKind::ComponentBinding => lsp_types::SymbolKind::PROPERTY,
+            SymbolKind::UiRouterState => lsp_types::SymbolKind::EVENT,
         }
     }
 }

--- a/tests/angularjs_common_syntax_test.rs
+++ b/tests/angularjs_common_syntax_test.rs
@@ -1727,6 +1727,204 @@ angular.module('app', []).config(['$stateProvider', function($stateProvider) {
 }
 
 #[test]
+fn test_state_provider_registers_state_name_definition() {
+    let source = r#"
+angular.module('app', []).config(['$stateProvider', function($stateProvider) {
+    $stateProvider.state('home', {
+        url: '/home',
+        templateUrl: 'views/home.html'
+    });
+}]);
+"#;
+    let index = analyze_js(source);
+    assert!(has_definition(&index, "home", SymbolKind::UiRouterState),
+        "$stateProvider.state('home', ...) で 'home' が UiRouterState として登録されるべき");
+}
+
+#[test]
+fn test_state_provider_dot_notation_state_name() {
+    let source = r#"
+angular.module('app', []).config(['$stateProvider', function($stateProvider) {
+    $stateProvider.state('users.detail', {
+        url: '/:id',
+        templateUrl: 'views/user-detail.html'
+    });
+}]);
+"#;
+    let index = analyze_js(source);
+    assert!(has_definition(&index, "users.detail", SymbolKind::UiRouterState),
+        "dot-notation の state 名 'users.detail' が UiRouterState として登録されるべき");
+}
+
+#[test]
+fn test_state_go_registers_reference() {
+    let source = r#"
+angular.module('app', [])
+    .config(['$stateProvider', function($stateProvider) {
+        $stateProvider.state('home', { url: '/home' });
+    }])
+    .controller('NavCtrl', ['$state', function($state) {
+        $state.go('home');
+    }]);
+"#;
+    let index = analyze_js(source);
+    let refs = index.definitions.get_references("home");
+    assert!(refs.iter().any(|r| r.uri.path() == "/test.js"),
+        "$state.go('home') で 'home' への参照が登録されるべき");
+}
+
+#[test]
+fn test_state_transition_to_registers_reference() {
+    let source = r#"
+angular.module('app', [])
+    .config(['$stateProvider', function($stateProvider) {
+        $stateProvider.state('about', { url: '/about' });
+    }])
+    .controller('NavCtrl', ['$state', function($state) {
+        $state.transitionTo('about');
+    }]);
+"#;
+    let index = analyze_js(source);
+    let refs = index.definitions.get_references("about");
+    assert_eq!(refs.len(), 1, "$state.transitionTo('about') で参照が登録されるべき");
+}
+
+#[test]
+fn test_state_go_via_di_renamed_param() {
+    // 配列 DI で $state を別名 (s) に rename しても認識されるべき
+    let source = r#"
+angular.module('app', [])
+    .controller('NavCtrl', ['$state', function(s) {
+        s.go('home');
+    }]);
+"#;
+    let index = analyze_js(source);
+    let refs = index.definitions.get_references("home");
+    assert!(!refs.is_empty(),
+        "DI 経由で rename された $state 経由でも 'home' への参照が登録されるべき");
+}
+
+#[test]
+fn test_state_go_on_unrelated_object_ignored() {
+    // $state ではない `state` 変数の .go() は無視されるべき
+    let source = r#"
+function unrelated() {
+    var state = { go: function() {} };
+    state.go('home');
+}
+"#;
+    let index = analyze_js(source);
+    let refs = index.definitions.get_references("home");
+    assert!(refs.is_empty(),
+        "$state でないオブジェクトの .go() は state 名参照として登録されないべき");
+}
+
+#[test]
+fn test_ui_sref_registers_html_reference() {
+    let js = r#"
+angular.module('app', []).config(['$stateProvider', function($stateProvider) {
+    $stateProvider.state('home', { url: '/home' });
+}]);
+"#;
+    let html = r#"<a ui-sref="home">Home</a>"#;
+    let index = analyze_html(js, html);
+
+    let html_uri = Url::parse("file:///test.html").unwrap();
+    let refs = index.html.get_ui_sref_references_for_uri(&html_uri);
+    assert_eq!(refs.len(), 1, "ui-sref='home' が HtmlUiSrefReference として登録されるべき");
+    assert_eq!(refs[0].state_name, "home");
+}
+
+#[test]
+fn test_ui_sref_with_params_strips_args() {
+    // ui-sref="home({id: 1})" の state 名は "home" のみ
+    let js = r#"
+angular.module('app', []).config(['$stateProvider', function($stateProvider) {
+    $stateProvider.state('home', { url: '/home/:id' });
+}]);
+"#;
+    let html = r#"<a ui-sref="home({id: 1})">Home</a>"#;
+    let index = analyze_html(js, html);
+
+    let html_uri = Url::parse("file:///test.html").unwrap();
+    let refs = index.html.get_ui_sref_references_for_uri(&html_uri);
+    assert_eq!(refs.len(), 1);
+    assert_eq!(refs[0].state_name, "home",
+        "ui-sref='home({{id: 1}})' から引数を除いた state 名 'home' が抽出されるべき");
+}
+
+#[test]
+fn test_ui_sref_dot_notation() {
+    let js = r#"
+angular.module('app', []).config(['$stateProvider', function($stateProvider) {
+    $stateProvider.state('users.detail', { url: '/:id' });
+}]);
+"#;
+    let html = r#"<a ui-sref="users.detail">User</a>"#;
+    let index = analyze_html(js, html);
+
+    let html_uri = Url::parse("file:///test.html").unwrap();
+    let refs = index.html.get_ui_sref_references_for_uri(&html_uri);
+    assert_eq!(refs.len(), 1);
+    assert_eq!(refs[0].state_name, "users.detail");
+}
+
+#[test]
+fn test_ui_sref_relative_refs_skipped() {
+    // 相対参照 '.' / '^' / '^.foo' は state 名を解決できないので登録しない
+    let js = r#"
+angular.module('app', []).config(['$stateProvider', function($stateProvider) {
+    $stateProvider.state('parent', {});
+}]);
+"#;
+    let html = r#"
+<a ui-sref="^">Up</a>
+<a ui-sref=".">Reload</a>
+<a ui-sref="^.sibling">Sibling</a>
+"#;
+    let index = analyze_html(js, html);
+
+    let html_uri = Url::parse("file:///test.html").unwrap();
+    let refs = index.html.get_ui_sref_references_for_uri(&html_uri);
+    assert!(refs.is_empty(),
+        "相対参照 ui-sref ('.', '^', '^.foo') は登録されないべき");
+}
+
+#[test]
+fn test_ui_sref_registers_symbol_reference_for_find_references() {
+    // ui-sref は find-references インフラ用に SymbolReference も登録する
+    let js = r#"
+angular.module('app', []).config(['$stateProvider', function($stateProvider) {
+    $stateProvider.state('home', {});
+}]);
+"#;
+    let html = r#"<a ui-sref="home">Home</a>"#;
+    let index = analyze_html(js, html);
+
+    let refs = index.definitions.get_references("home");
+    let html_uri = Url::parse("file:///test.html").unwrap();
+    assert!(refs.iter().any(|r| r.uri == html_uri),
+        "ui-sref='home' が SymbolReference としても登録されるべき");
+}
+
+#[test]
+fn test_ui_sref_active_attribute_not_treated_as_state_ref() {
+    // ui-sref-active の値は CSS class なので state 名参照としては扱わない
+    let js = r#"
+angular.module('app', []).config(['$stateProvider', function($stateProvider) {
+    $stateProvider.state('home', {});
+}]);
+"#;
+    let html = r#"<a ui-sref="home" ui-sref-active="active">Home</a>"#;
+    let index = analyze_html(js, html);
+
+    let html_uri = Url::parse("file:///test.html").unwrap();
+    let refs = index.html.get_ui_sref_references_for_uri(&html_uri);
+    assert_eq!(refs.len(), 1, "ui-sref のみが登録され、ui-sref-active='active' は無視されるべき");
+    assert_eq!(refs[0].state_name, "home");
+}
+
+#[test]
 fn test_state_provider_top_level_and_named_views_coexist() {
     // 親 state に templateUrl/controller がありつつ views も持つケース
     // (両方とも binding として登録される)
@@ -3655,6 +3853,93 @@ angular.module('app', []).controller('PaginationCtrl', ['$scope', function($scop
         "hover に property 名 currentPage が含まれるべき (value: {})",
         value
     );
+}
+
+#[test]
+fn test_goto_definition_from_ui_sref_to_state_definition() {
+    // HTML 上の `ui-sref="home"` の "home" にカーソルがあれば、
+    // JS 上の `$stateProvider.state('home', ...)` にジャンプすべき。
+    use angularjs_lsp::handler::DefinitionHandler;
+    use std::sync::Arc;
+    use tower_lsp::lsp_types::{
+        GotoDefinitionParams, GotoDefinitionResponse, PartialResultParams, Position,
+        TextDocumentIdentifier, TextDocumentPositionParams, WorkDoneProgressParams,
+    };
+
+    let js = r#"
+angular.module('app', []).config(['$stateProvider', function($stateProvider) {
+    $stateProvider.state('home', { url: '/home' });
+}]);
+"#;
+    let html = r#"<a ui-sref="home">Home</a>"#;
+    let index = analyze_html(js, html);
+    let html_uri = Url::parse("file:///test.html").unwrap();
+    let js_uri = Url::parse("file:///test.js").unwrap();
+
+    let handler = DefinitionHandler::new(Arc::clone(&index));
+    // ui-sref="home" の値の "home" にカーソル
+    // <a ui-sref="home">Home</a>
+    //  0123456789012345
+    //             ^ col 12 (h)
+    let params = GotoDefinitionParams {
+        text_document_position_params: TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier {
+                uri: html_uri.clone(),
+            },
+            position: Position { line: 0, character: 13 },
+        },
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+    };
+    let response = handler
+        .goto_definition(params)
+        .expect("ui-sref から state 定義へジャンプすべき");
+
+    let location = match response {
+        GotoDefinitionResponse::Scalar(loc) => loc,
+        GotoDefinitionResponse::Array(locs) => locs.into_iter().next().expect("at least one"),
+        GotoDefinitionResponse::Link(_) => panic!("unexpected Link"),
+    };
+
+    assert_eq!(location.uri, js_uri,
+        "ui-sref のジャンプ先は JS の state 定義ファイルであるべき");
+}
+
+#[test]
+fn test_hover_on_ui_sref_returns_state_definition_info() {
+    use angularjs_lsp::handler::HoverHandler;
+    use std::sync::Arc;
+    use tower_lsp::lsp_types::{
+        HoverContents, HoverParams, Position, TextDocumentIdentifier,
+        TextDocumentPositionParams, WorkDoneProgressParams,
+    };
+
+    let js = r#"
+angular.module('app', []).config(['$stateProvider', function($stateProvider) {
+    $stateProvider.state('home', { url: '/home' });
+}]);
+"#;
+    let html = r#"<a ui-sref="home">Home</a>"#;
+    let index = analyze_html(js, html);
+    let html_uri = Url::parse("file:///test.html").unwrap();
+
+    let handler = HoverHandler::new(Arc::clone(&index));
+    let params = HoverParams {
+        text_document_position_params: TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier { uri: html_uri },
+            position: Position { line: 0, character: 13 },
+        },
+        work_done_progress_params: WorkDoneProgressParams::default(),
+    };
+    let hover = handler.hover(params).expect("ui-sref の hover が返るべき");
+    let value = match hover.contents {
+        HoverContents::Markup(m) => m.value,
+        _ => panic!("expected Markup hover"),
+    };
+    assert!(value.contains("home"),
+        "hover に state 名 'home' が含まれるべき (value: {})", value);
+    assert!(value.contains("ui-router state"),
+        "hover に kind 'ui-router state' が含まれるべき (value: {})", value);
 }
 
 #[test]


### PR DESCRIPTION
**注意**: PR #43 (named views) にスタックされています。先に #43 をマージしてからこちらをマージしてください。
PR #43 がマージされれば、このPRの base は自動的に master に切り替わります。

## Summary

ui-router の state 名 (`$stateProvider.state('home', ...)`) を `SymbolKind::UiRouterState` として
登録し、HTML/JS 両側からの参照を双方向ジャンプ可能にする。

```html
<a ui-sref="home">Home</a>          <!-- → JS の state 定義へジャンプ -->
<a ui-sref="users.detail">User</a>  <!-- dot-notation 子 state -->
<a ui-sref="home({id: 1})">User</a> <!-- 引数付き (state 名のみ抽出) -->
```

```javascript
.controller('NavCtrl', ['$state', function($state) {
    $state.go('home');           // → state 定義へジャンプ
    $state.transitionTo('home'); // 同上
}])
```

## 主な変更

### 解析側
- `extract_state_provider_di` (src/analyzer/js/component.rs): 第1引数の文字列を UiRouterState として登録
- `is_state_service_receiver` (新): `$state` を厳密判定 (`state` 変数は除外)、DI rename も対応
- `extract_state_navigation_reference` (新): `$state.go()` / `.transitionTo()` の第1引数を SymbolReference として登録
- `register_ui_sref_reference` (新, src/analyzer/html/scope_reference.rs): ui-sref 値を `(` で分割して state 名を抽出。相対参照 (`.`, `^`, `^.foo`) はスキップ

### モデル / ストア
- `SymbolKind::UiRouterState` 追加 (src/model/symbol.rs)
- `HtmlUiSrefReference` 追加 (src/model/html.rs) — find_at_position で HTML 上の位置検索に使用
- `HtmlStore` に ui_sref_references 用の `add` / `find_at` / `get_by_state` API を追加

### ハンドラ
- DefinitionHandler: ui-sref 上で goto-definition → state 定義へ
- HoverHandler: ui-sref 上で hover → state 定義のホバー情報
- ReferencesHandler: state 名から HTML+JS 参照を横断的に列挙 (UiRouterState kind に絞る)

### ドキュメント
- `UNSUPPORTED_FEATURES.md` 更新: 対応済み機能を明記、未対応 (resolve, ui-view named view, 相対参照, ui-state) を残置

## Test plan

- [x] `cargo test` 全件通過 (lib 161 + integration 148)
- [x] 新規テスト 14 件すべて通過
  - state 定義登録 / dot-notation / \$state.go / .transitionTo / DI rename / 誤検知防止
  - ui-sref 基本 / 引数除外 / dot-notation / 相対参照スキップ / SymbolReference 登録 / sref-active 除外
  - ハンドラ E2E: goto-definition / hover from ui-sref
- [x] `cargo clippy --lib --tests` で新規 warning なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)