### PR TITLE
refactor: introduce span_of helper for Node->Span conversion

### DIFF
--- a/src/analyzer/js/component.rs
+++ b/src/analyzer/js/component.rs
@@ -308,17 +308,10 @@ impl AngularJsAnalyzer {
         if let (Some(name), Some(value_node)) =
             (controller_name.as_ref(), controller_string_value_node)
         {
-            let start = value_node.start_position();
-            let end = value_node.end_position();
             let reference = SymbolReference {
                 name: name.clone(),
                 uri: uri.clone(),
-                span: Span::new(
-                    self.offset_line(start.row as u32),
-                    start.column as u32,
-                    self.offset_line(end.row as u32),
-                    end.column as u32,
-                ),
+                span: self.span_of(value_node),
             };
             self.index.definitions.add_reference(reference);
         }
@@ -481,17 +474,10 @@ impl AngularJsAnalyzer {
                             // controller: 'ControllerName' パターンは参照登録のみ
                             if value.kind() == "string" {
                                 let controller_name = self.extract_string_value(value, source);
-                                let start = value.start_position();
-                                let end = value.end_position();
                                 let reference = SymbolReference {
                                     name: controller_name,
                                     uri: uri.clone(),
-                                    span: Span::new(
-                                        self.offset_line(start.row as u32),
-                                        start.column as u32,
-                                        self.offset_line(end.row as u32),
-                                        end.column as u32,
-                                    ),
+                                    span: self.span_of(value),
                                 };
                                 self.index.definitions.add_reference(reference);
                             } else {
@@ -550,14 +536,7 @@ impl AngularJsAnalyzer {
             if let Some(name_arg) = args.named_child(0) {
                 if name_arg.kind() == "string" {
                     let state_name = self.extract_string_value(name_arg, source);
-                    let start = name_arg.start_position();
-                    let end = name_arg.end_position();
-                    let span = Span::new(
-                        self.offset_line(start.row as u32),
-                        start.column as u32,
-                        self.offset_line(end.row as u32),
-                        end.column as u32,
-                    );
+                    let span = self.span_of(name_arg);
 
                     let symbol = SymbolBuilder::new(
                         state_name,
@@ -631,17 +610,10 @@ impl AngularJsAnalyzer {
             return;
         }
         let state_name = self.extract_string_value(first_arg, source);
-        let start = first_arg.start_position();
-        let end = first_arg.end_position();
         self.index.definitions.add_reference(SymbolReference {
             name: state_name,
             uri: uri.clone(),
-            span: Span::new(
-                self.offset_line(start.row as u32),
-                start.column as u32,
-                self.offset_line(end.row as u32),
-                end.column as u32,
-            ),
+            span: self.span_of(first_arg),
         });
     }
 
@@ -666,17 +638,10 @@ impl AngularJsAnalyzer {
                             // controller: 'ControllerName' パターンは参照登録のみ
                             if value.kind() == "string" {
                                 let controller_name = self.extract_string_value(value, source);
-                                let start = value.start_position();
-                                let end = value.end_position();
                                 let reference = SymbolReference {
                                     name: controller_name,
                                     uri: uri.clone(),
-                                    span: Span::new(
-                                        self.offset_line(start.row as u32),
-                                        start.column as u32,
-                                        self.offset_line(end.row as u32),
-                                        end.column as u32,
-                                    ),
+                                    span: self.span_of(value),
                                 };
                                 self.index.definitions.add_reference(reference);
                             } else {
@@ -778,18 +743,12 @@ impl AngularJsAnalyzer {
                 if first_arg.kind() == "string" {
                     let name = self.extract_string_value(first_arg, source);
                     let start = first_arg.start_position();
-                    let end = first_arg.end_position();
 
                     // 現在のモジュール名をコンテキストに設定
                     ctx.set_current_module(name.clone());
 
                     let docs = self.extract_jsdoc_for_line(start.row, source);
-                    let span = Span::new(
-                        self.offset_line(start.row as u32),
-                        start.column as u32,
-                        self.offset_line(end.row as u32),
-                        end.column as u32,
-                    );
+                    let span = self.span_of(first_arg);
 
                     let mut builder = SymbolBuilder::new(name.clone(), SymbolKind::Module, uri.clone())
                         .definition_span(span)
@@ -822,8 +781,7 @@ impl AngularJsAnalyzer {
                     let component_name = self.extract_string_value(first_arg, source);
 
                     // シンボル名の位置（検索用）は常に文字列リテラルの位置
-                    let name_start = first_arg.start_position();
-                    let name_end = first_arg.end_position();
+                    let name_span = self.span_of(first_arg);
 
                     // 定義位置は関数定義を優先する
                     let (start, end, docs_line) = if let Some(second_arg) = args.named_child(1) {
@@ -890,12 +848,6 @@ impl AngularJsAnalyzer {
                         start.column as u32,
                         self.offset_line(end.row as u32),
                         end.column as u32,
-                    );
-                    let name_span = Span::new(
-                        self.offset_line(name_start.row as u32),
-                        name_start.column as u32,
-                        self.offset_line(name_end.row as u32),
-                        name_end.column as u32,
                     );
 
                     let mut builder = SymbolBuilder::new(component_name.clone(), kind, uri.clone())
@@ -1089,36 +1041,24 @@ impl AngularJsAnalyzer {
         uri: &Url,
         _ctx: &mut AnalyzerContext,
     ) {
-        let name_start = name_node.start_position();
-        let name_end = name_node.end_position();
+        let name_span = self.span_of(name_node);
 
         // 定義位置はconfig objectがあればその位置、なければname_nodeの位置
-        let (start, end) = if let Some(config) = config_node {
+        let def_node = if let Some(config) = config_node {
             // config オブジェクトから templateUrl, bindings を抽出
             if config.kind() == "object" {
                 self.extract_component_template_url(config, source, uri, Some(component_name));
                 // controller プロパティからthis/aliasメソッドを抽出
                 self.extract_component_controller_methods(config, source, uri, component_name);
             }
-            (config.start_position(), config.end_position())
+            config
         } else {
-            (name_start, name_end)
+            name_node
         };
 
-        let docs = self.extract_jsdoc_for_line(name_start.row, source);
+        let docs = self.extract_jsdoc_for_line(name_node.start_position().row, source);
 
-        let def_span = Span::new(
-            self.offset_line(start.row as u32),
-            start.column as u32,
-            self.offset_line(end.row as u32),
-            end.column as u32,
-        );
-        let name_span = Span::new(
-            self.offset_line(name_start.row as u32),
-            name_start.column as u32,
-            self.offset_line(name_end.row as u32),
-            name_end.column as u32,
-        );
+        let def_span = self.span_of(def_node);
 
         let mut builder = SymbolBuilder::new(component_name.to_string(), SymbolKind::Component, uri.clone())
             .definition_span(def_span)
@@ -1283,19 +1223,11 @@ impl AngularJsAnalyzer {
                         None
                     };
 
-                    let start = key.start_position();
-                    let end = key.end_position();
-
                     // ControllerName.bindingName として登録
                     let full_name = format!("{}.{}", controller_name, binding_name);
                     let docs = binding_type.map(|t| format!("Component binding: {}", t));
 
-                    let span = Span::new(
-                        self.offset_line(start.row as u32),
-                        start.column as u32,
-                        self.offset_line(end.row as u32),
-                        end.column as u32,
-                    );
+                    let span = self.span_of(key);
 
                     let mut builder = SymbolBuilder::new(full_name, SymbolKind::ComponentBinding, uri.clone())
                         .definition_span(span)

--- a/src/analyzer/js/di.rs
+++ b/src/analyzer/js/di.rs
@@ -5,7 +5,7 @@ use tree_sitter::Node;
 
 use super::context::{AnalyzerContext, DiInfo};
 use super::AngularJsAnalyzer;
-use crate::model::{ControllerScope, Span, SymbolReference};
+use crate::model::{ControllerScope, SymbolReference};
 
 impl AngularJsAnalyzer {
     /// ES6 classノードからconstructorメソッドを取得する
@@ -132,18 +132,10 @@ impl AngularJsAnalyzer {
                 if child.kind() == "string" {
                     let dep_name = self.extract_string_value(child, source);
                     if !dep_name.starts_with('$') {
-                        let start = child.start_position();
-                        let end = child.end_position();
-
                         let reference = SymbolReference {
                             name: dep_name,
                             uri: uri.clone(),
-                            span: Span::new(
-                                self.offset_line(start.row as u32),
-                                start.column as u32,
-                                self.offset_line(end.row as u32),
-                                end.column as u32,
-                            ),
+                            span: self.span_of(child),
                         };
 
                         self.index.definitions.add_reference(reference);
@@ -168,18 +160,10 @@ impl AngularJsAnalyzer {
                 if child.kind() == "string" {
                     let dep_name = self.extract_string_value(child, source);
                     if !dep_name.starts_with('$') {
-                        let start = child.start_position();
-                        let end = child.end_position();
-
                         let reference = SymbolReference {
                             name: dep_name,
                             uri: uri.clone(),
-                            span: Span::new(
-                                self.offset_line(start.row as u32),
-                                start.column as u32,
-                                self.offset_line(end.row as u32),
-                                end.column as u32,
-                            ),
+                            span: self.span_of(child),
                         };
 
                         self.index.definitions.add_reference(reference);

--- a/src/analyzer/js/export.rs
+++ b/src/analyzer/js/export.rs
@@ -153,18 +153,8 @@ impl AngularJsAnalyzer {
         self.index.exports.add_export(export_info);
 
         // Symbol として登録（Go to Definition 用）
-        let def_span = Span::new(
-            self.offset_line(array_node.start_position().row as u32),
-            array_node.start_position().column as u32,
-            self.offset_line(array_node.end_position().row as u32),
-            array_node.end_position().column as u32,
-        );
-        let name_span = Span::new(
-            self.offset_line(last.start_position().row as u32),
-            last.start_position().column as u32,
-            self.offset_line(last.end_position().row as u32),
-            last.end_position().column as u32,
-        );
+        let def_span = self.span_of(array_node);
+        let name_span = self.span_of(*last);
 
         let symbol = SymbolBuilder::new(component_name.clone(), SymbolKind::ExportedComponent, uri.clone())
             .definition_span(def_span)
@@ -339,17 +329,7 @@ impl AngularJsAnalyzer {
             "function_declaration" => {
                 if let Some(name_node) = node.child_by_field_name("name") {
                     let func_name = self.node_text(name_node, source);
-                    let start = node.start_position();
-                    let end = node.end_position();
-                    local_vars.insert(
-                        func_name,
-                        Span::new(
-                            self.offset_line(start.row as u32),
-                            start.column as u32,
-                            self.offset_line(end.row as u32),
-                            end.column as u32,
-                        ),
-                    );
+                    local_vars.insert(func_name, self.span_of(node));
                 }
             }
             "variable_declaration" | "lexical_declaration" => {
@@ -363,17 +343,7 @@ impl AngularJsAnalyzer {
                                     "function_expression" | "arrow_function"
                                 ) {
                                     let var_name = self.node_text(name_node, source);
-                                    let start = value_node.start_position();
-                                    let end = value_node.end_position();
-                                    local_vars.insert(
-                                        var_name,
-                                        Span::new(
-                                            self.offset_line(start.row as u32),
-                                            start.column as u32,
-                                            self.offset_line(end.row as u32),
-                                            end.column as u32,
-                                        ),
-                                    );
+                                    local_vars.insert(var_name, self.span_of(value_node));
                                 }
                             }
                         }
@@ -457,8 +427,6 @@ impl AngularJsAnalyzer {
                     if is_this_or_alias {
                         if let Some(property) = left.child_by_field_name("property") {
                             let method_name = self.node_text(property, source);
-                            let start = property.start_position();
-                            let end = property.end_position();
 
                             let docs =
                                 self.extract_jsdoc_for_line(assign_node.start_position().row, source);
@@ -468,12 +436,7 @@ impl AngularJsAnalyzer {
                                 .and_then(|right| self.extract_function_params(right, source));
 
                             let full_name = format!("{}.{}", component_name, method_name);
-                            let span = Span::new(
-                                self.offset_line(start.row as u32),
-                                start.column as u32,
-                                self.offset_line(end.row as u32),
-                                end.column as u32,
-                            );
+                            let span = self.span_of(property);
 
                             let mut builder = SymbolBuilder::new(full_name, SymbolKind::Method, uri.clone())
                                 .definition_span(span)
@@ -511,28 +474,14 @@ impl AngularJsAnalyzer {
                         if let Some(value) = child.child_by_field_name("value") {
                             let method_name = self.node_text(key, source);
                             let full_name = format!("{}.{}", component_name, method_name);
-                            let name_start = key.start_position();
-                            let name_end = key.end_position();
-                            let name_span = Span::new(
-                                self.offset_line(name_start.row as u32),
-                                name_start.column as u32,
-                                self.offset_line(name_end.row as u32),
-                                name_end.column as u32,
-                            );
+                            let name_span = self.span_of(key);
 
                             match value.kind() {
                                 "function_expression" | "arrow_function" => {
-                                    let start = key.start_position();
-                                    let end = key.end_position();
                                     let docs = self
                                         .extract_jsdoc_for_line(child.start_position().row, source);
                                     let parameters = self.extract_function_params(value, source);
-                                    let def_span = Span::new(
-                                        self.offset_line(start.row as u32),
-                                        start.column as u32,
-                                        self.offset_line(end.row as u32),
-                                        end.column as u32,
-                                    );
+                                    let def_span = self.span_of(key);
 
                                     let mut builder = SymbolBuilder::new(full_name, SymbolKind::Method, uri.clone())
                                         .definition_span(def_span)
@@ -563,16 +512,9 @@ impl AngularJsAnalyzer {
 
                                         self.index.definitions.add_definition(builder.build());
                                     } else {
-                                        let start = key.start_position();
-                                        let end = key.end_position();
                                         let docs = self
                                             .extract_jsdoc_for_line(child.start_position().row, source);
-                                        let def_span = Span::new(
-                                            self.offset_line(start.row as u32),
-                                            start.column as u32,
-                                            self.offset_line(end.row as u32),
-                                            end.column as u32,
-                                        );
+                                        let def_span = self.span_of(key);
 
                                         let mut builder = SymbolBuilder::new(full_name, SymbolKind::Method, uri.clone())
                                             .definition_span(def_span)
@@ -593,14 +535,7 @@ impl AngularJsAnalyzer {
                 "shorthand_property_identifier" => {
                     let method_name = self.node_text(child, source);
                     let full_name = format!("{}.{}", component_name, method_name);
-                    let name_start = child.start_position();
-                    let name_end = child.end_position();
-                    let name_span = Span::new(
-                        self.offset_line(name_start.row as u32),
-                        name_start.column as u32,
-                        self.offset_line(name_end.row as u32),
-                        name_end.column as u32,
-                    );
+                    let name_span = self.span_of(child);
 
                     if let Some(var_span) = local_vars.get(&method_name) {
                         let docs = self.extract_jsdoc_for_line(var_span.start_line as usize, source);
@@ -615,15 +550,8 @@ impl AngularJsAnalyzer {
 
                         self.index.definitions.add_definition(builder.build());
                     } else {
-                        let start = child.start_position();
-                        let end = child.end_position();
-                        let docs = self.extract_jsdoc_for_line(start.row, source);
-                        let def_span = Span::new(
-                            self.offset_line(start.row as u32),
-                            start.column as u32,
-                            self.offset_line(end.row as u32),
-                            end.column as u32,
-                        );
+                        let docs = self.extract_jsdoc_for_line(child.start_position().row, source);
+                        let def_span = self.span_of(child);
 
                         let mut builder = SymbolBuilder::new(full_name, SymbolKind::Method, uri.clone())
                             .definition_span(def_span)
@@ -697,12 +625,7 @@ impl AngularJsAnalyzer {
         self.index.exports.add_export(export_info);
 
         // Symbol として登録
-        let span = Span::new(
-            self.offset_line(node.start_position().row as u32),
-            node.start_position().column as u32,
-            self.offset_line(node.end_position().row as u32),
-            node.end_position().column as u32,
-        );
+        let span = self.span_of(node);
 
         let symbol = SymbolBuilder::new(identifier_name.clone(), SymbolKind::ExportedComponent, uri.clone())
             .definition_span(span)
@@ -775,18 +698,8 @@ impl AngularJsAnalyzer {
             self.index.exports.add_exported_component_object(exported_obj);
 
             // Symbol としても登録（Go to Definition 用）
-            let def_span = Span::new(
-                self.offset_line(obj_node.start_position().row as u32),
-                obj_node.start_position().column as u32,
-                self.offset_line(obj_node.end_position().row as u32),
-                obj_node.end_position().column as u32,
-            );
-            let name_span = Span::new(
-                self.offset_line(name_pos.start_position().row as u32),
-                name_pos.start_position().column as u32,
-                self.offset_line(name_pos.end_position().row as u32),
-                name_pos.end_position().column as u32,
-            );
+            let def_span = self.span_of(obj_node);
+            let name_span = self.span_of(name_pos);
 
             let symbol = SymbolBuilder::new(name, SymbolKind::Component, uri.clone())
                 .definition_span(def_span)
@@ -909,18 +822,10 @@ impl AngularJsAnalyzer {
                         None
                     };
 
-                    let start = key.start_position();
-                    let end = key.end_position();
-
                     let full_name = format!("{}.{}", controller_name, binding_name);
                     let docs = binding_type.map(|t| format!("Component binding: {}", t));
 
-                    let span = Span::new(
-                        self.offset_line(start.row as u32),
-                        start.column as u32,
-                        self.offset_line(end.row as u32),
-                        end.column as u32,
-                    );
+                    let span = self.span_of(key);
 
                     let mut builder = SymbolBuilder::new(full_name, SymbolKind::ComponentBinding, uri.clone())
                         .definition_span(span)

--- a/src/analyzer/js/mod.rs
+++ b/src/analyzer/js/mod.rs
@@ -18,6 +18,7 @@ use tower_lsp::lsp_types::Url;
 use tree_sitter::{Node, Tree};
 
 use crate::index::Index;
+use crate::model::Span;
 use context::AnalyzerContext;
 use parser::JsParser;
 
@@ -183,6 +184,20 @@ impl AngularJsAnalyzer {
     /// 行番号にオフセットを加算
     pub(super) fn offset_line(&self, line: u32) -> u32 {
         line + self.line_offset.load(Ordering::Relaxed)
+    }
+
+    /// tree-sitter `Node` から `Span` を作る。
+    ///
+    /// 行番号は `offset_line` を経由して埋め込みスクリプト用のオフセットを反映する。
+    pub(super) fn span_of(&self, node: Node) -> Span {
+        let start = node.start_position();
+        let end = node.end_position();
+        Span::new(
+            self.offset_line(start.row as u32),
+            start.column as u32,
+            self.offset_line(end.row as u32),
+            end.column as u32,
+        )
     }
 
     /// ASTノードからソーステキストを取得する

--- a/src/analyzer/js/reference.rs
+++ b/src/analyzer/js/reference.rs
@@ -3,7 +3,7 @@ use tree_sitter::Node;
 
 use super::context::AnalyzerContext;
 use super::AngularJsAnalyzer;
-use crate::model::{Span, SymbolReference};
+use crate::model::SymbolReference;
 
 /// Utility: check if name is a common JavaScript keyword
 pub(super) fn is_common_keyword(name: &str) -> bool {
@@ -64,18 +64,10 @@ impl AngularJsAnalyzer {
                         let full_name = format!("{}.{}", obj_name, method_name);
 
                         if self.index.definitions.has_definition(&full_name) {
-                            let start = property.start_position();
-                            let end = property.end_position();
-
                             let reference = SymbolReference {
                                 name: full_name,
                                 uri: uri.clone(),
-                                span: Span::new(
-                                    self.offset_line(start.row as u32),
-                                    start.column as u32,
-                                    self.offset_line(end.row as u32),
-                                    end.column as u32,
-                                ),
+                                span: self.span_of(property),
                             };
 
                             self.index.definitions.add_reference(reference);
@@ -113,18 +105,10 @@ impl AngularJsAnalyzer {
                 let full_name = format!("{}.{}", obj_name, prop_name);
 
                 if self.index.definitions.has_definition(&full_name) {
-                    let start = property.start_position();
-                    let end = property.end_position();
-
                     let reference = SymbolReference {
                         name: full_name,
                         uri: uri.clone(),
-                        span: Span::new(
-                            self.offset_line(start.row as u32),
-                            start.column as u32,
-                            self.offset_line(end.row as u32),
-                            end.column as u32,
-                        ),
+                        span: self.span_of(property),
                     };
 
                     self.index.definitions.add_reference(reference);
@@ -153,18 +137,10 @@ impl AngularJsAnalyzer {
                 return;
             }
 
-            let start = node.start_position();
-            let end = node.end_position();
-
             let reference = SymbolReference {
                 name,
                 uri: uri.clone(),
-                span: Span::new(
-                    self.offset_line(start.row as u32),
-                    start.column as u32,
-                    self.offset_line(end.row as u32),
-                    end.column as u32,
-                ),
+                span: self.span_of(node),
             };
 
             self.index.definitions.add_reference(reference);

--- a/src/analyzer/js/scope.rs
+++ b/src/analyzer/js/scope.rs
@@ -3,7 +3,7 @@ use tree_sitter::Node;
 
 use super::context::AnalyzerContext;
 use super::AngularJsAnalyzer;
-use crate::model::{Span, SymbolBuilder, SymbolKind, SymbolReference};
+use crate::model::{SymbolBuilder, SymbolKind, SymbolReference};
 
 impl AngularJsAnalyzer {
     /// $scope.property への代入を解析し、定義として登録する
@@ -44,27 +44,16 @@ impl AngularJsAnalyzer {
                             // 既に定義済みの場合は参照として登録
                             if ctx.defined_scope_properties.contains_key(&full_name) {
                                 // 代入の左辺も参照としてカウント
-                                let start = property.start_position();
-                                let end = property.end_position();
-
                                 let reference = SymbolReference {
                                     name: full_name,
                                     uri: uri.clone(),
-                                    span: Span::new(
-                                        self.offset_line(start.row as u32),
-                                        start.column as u32,
-                                        self.offset_line(end.row as u32),
-                                        end.column as u32,
-                                    ),
+                                    span: self.span_of(property),
                                 };
 
                                 self.index.definitions.add_reference(reference);
                                 return;
                             }
                             ctx.defined_scope_properties.insert(full_name.clone(), true);
-
-                            let prop_start = property.start_position();
-                            let prop_end = property.end_position();
 
                             // JSDocを探す
                             let docs = self.extract_jsdoc_for_line(node.start_position().row, source);
@@ -88,18 +77,8 @@ impl AngularJsAnalyzer {
                                 SymbolKind::ScopeProperty
                             };
 
-                            let def_span = Span::new(
-                                self.offset_line(prop_start.row as u32),
-                                prop_start.column as u32,
-                                self.offset_line(prop_end.row as u32),
-                                prop_end.column as u32,
-                            );
-                            let name_span = Span::new(
-                                self.offset_line(prop_start.row as u32),
-                                prop_start.column as u32,
-                                self.offset_line(prop_end.row as u32),
-                                prop_end.column as u32,
-                            );
+                            let def_span = self.span_of(property);
+                            let name_span = self.span_of(property);
 
                             let mut builder = SymbolBuilder::new(full_name, kind, uri.clone())
                                 .definition_span(def_span)
@@ -164,19 +143,11 @@ impl AngularJsAnalyzer {
                     // シンボル名を生成
                     let full_name = format!("{}.$scope.{}", controller_name, prop_name);
 
-                    let start = property.start_position();
-                    let end = property.end_position();
-
                     // 定義がなくても参照として登録（非同期処理内での定義など）
                     let reference = SymbolReference {
                         name: full_name,
                         uri: uri.clone(),
-                        span: Span::new(
-                            self.offset_line(start.row as u32),
-                            start.column as u32,
-                            self.offset_line(end.row as u32),
-                            end.column as u32,
-                        ),
+                        span: self.span_of(property),
                     };
 
                     self.index.definitions.add_reference(reference);
@@ -223,27 +194,16 @@ impl AngularJsAnalyzer {
                             // 既に定義済みの場合は参照として登録
                             if ctx.defined_root_scope_properties.contains_key(&full_name) {
                                 // 代入の左辺も参照としてカウント
-                                let start = property.start_position();
-                                let end = property.end_position();
-
                                 let reference = SymbolReference {
                                     name: full_name,
                                     uri: uri.clone(),
-                                    span: Span::new(
-                                        self.offset_line(start.row as u32),
-                                        start.column as u32,
-                                        self.offset_line(end.row as u32),
-                                        end.column as u32,
-                                    ),
+                                    span: self.span_of(property),
                                 };
 
                                 self.index.definitions.add_reference(reference);
                                 return;
                             }
                             ctx.defined_root_scope_properties.insert(full_name.clone(), true);
-
-                            let prop_start = property.start_position();
-                            let prop_end = property.end_position();
 
                             // JSDocを探す
                             let docs = self.extract_jsdoc_for_line(node.start_position().row, source);
@@ -267,18 +227,8 @@ impl AngularJsAnalyzer {
                                 SymbolKind::RootScopeProperty
                             };
 
-                            let def_span = Span::new(
-                                self.offset_line(prop_start.row as u32),
-                                prop_start.column as u32,
-                                self.offset_line(prop_end.row as u32),
-                                prop_end.column as u32,
-                            );
-                            let name_span = Span::new(
-                                self.offset_line(prop_start.row as u32),
-                                prop_start.column as u32,
-                                self.offset_line(prop_end.row as u32),
-                                prop_end.column as u32,
-                            );
+                            let def_span = self.span_of(property);
+                            let name_span = self.span_of(property);
 
                             let mut builder = SymbolBuilder::new(full_name, kind, uri.clone())
                                 .definition_span(def_span)
@@ -343,19 +293,11 @@ impl AngularJsAnalyzer {
                     // シンボル名を生成
                     let full_name = format!("{}.$rootScope.{}", module_name, prop_name);
 
-                    let start = property.start_position();
-                    let end = property.end_position();
-
                     // 定義がなくても参照として登録（非同期処理内での定義など）
                     let reference = SymbolReference {
                         name: full_name,
                         uri: uri.clone(),
-                        span: Span::new(
-                            self.offset_line(start.row as u32),
-                            start.column as u32,
-                            self.offset_line(end.row as u32),
-                            end.column as u32,
-                        ),
+                        span: self.span_of(property),
                     };
 
                     self.index.definitions.add_reference(reference);

--- a/src/analyzer/js/service_method.rs
+++ b/src/analyzer/js/service_method.rs
@@ -5,7 +5,7 @@ use tree_sitter::Node;
 
 use super::context::LocalVarLocation;
 use super::AngularJsAnalyzer;
-use crate::model::{Span, SymbolBuilder, SymbolKind};
+use crate::model::{SymbolBuilder, SymbolKind};
 
 impl AngularJsAnalyzer {
     /// サービス/ファクトリーの実装関数からメソッドを抽出する
@@ -83,9 +83,6 @@ impl AngularJsAnalyzer {
                             continue;
                         }
 
-                        let start = name_node.start_position();
-                        let end = name_node.end_position();
-
                         // JSDocを抽出
                         let docs = self.extract_jsdoc_for_line(child.start_position().row, source);
 
@@ -94,12 +91,7 @@ impl AngularJsAnalyzer {
                             .and_then(|params| self.extract_params_from_node(params, source));
 
                         let full_name = format!("{}.{}", service_name, method_name);
-                        let span = Span::new(
-                            self.offset_line(start.row as u32),
-                            start.column as u32,
-                            self.offset_line(end.row as u32),
-                            end.column as u32,
-                        );
+                        let span = self.span_of(name_node);
 
                         let mut builder = SymbolBuilder::new(full_name, SymbolKind::Method, uri.clone())
                             .definition_span(span)
@@ -187,16 +179,8 @@ impl AngularJsAnalyzer {
             if let Some(name_node) = node.child_by_field_name("name") {
                 let func_name = self.node_text(name_node, source);
                 // 関数名ではなく関数宣言全体の位置を記録する
-                let start = node.start_position();
-                let end = node.end_position();
-
                 func_decls.insert(func_name, LocalVarLocation {
-                    span: Span::new(
-                        self.offset_line(start.row as u32),
-                        start.column as u32,
-                        self.offset_line(end.row as u32),
-                        end.column as u32,
-                    ),
+                    span: self.span_of(node),
                 });
             }
         }
@@ -261,16 +245,8 @@ impl AngularJsAnalyzer {
                                     || value_node.kind() == "arrow_function"
                                 {
                                     let var_name = self.node_text(name_node, source);
-                                    let start = value_node.start_position();
-                                    let end = value_node.end_position();
-
                                     local_vars.insert(var_name, LocalVarLocation {
-                                        span: Span::new(
-                                            self.offset_line(start.row as u32),
-                                            start.column as u32,
-                                            self.offset_line(end.row as u32),
-                                            end.column as u32,
-                                        ),
+                                        span: self.span_of(value_node),
                                     });
                                 }
                             }
@@ -380,8 +356,6 @@ impl AngularJsAnalyzer {
                     if self.node_text(object, source) == returned_var {
                         if let Some(property) = left.child_by_field_name("property") {
                             let method_name = self.node_text(property, source);
-                            let start = property.start_position();
-                            let end = property.end_position();
 
                             let docs = self.extract_jsdoc_for_line(assign_node.start_position().row, source);
 
@@ -391,12 +365,7 @@ impl AngularJsAnalyzer {
                                 .and_then(|right| self.extract_function_params(right, source));
 
                             let full_name = format!("{}.{}", service_name, method_name);
-                            let span = Span::new(
-                                self.offset_line(start.row as u32),
-                                start.column as u32,
-                                self.offset_line(end.row as u32),
-                                end.column as u32,
-                            );
+                            let span = self.span_of(property);
 
                             let mut builder = SymbolBuilder::new(full_name, SymbolKind::Method, uri.clone())
                                 .definition_span(span)
@@ -436,8 +405,6 @@ impl AngularJsAnalyzer {
                     if obj_text == "this" || this_aliases.contains(&obj_text) {
                         if let Some(property) = left.child_by_field_name("property") {
                             let method_name = self.node_text(property, source);
-                            let start = property.start_position();
-                            let end = property.end_position();
 
                             // 代入文の行からJSDocを探す
                             let docs = self.extract_jsdoc_for_line(assign_node.start_position().row, source);
@@ -448,12 +415,7 @@ impl AngularJsAnalyzer {
                                 .and_then(|right| self.extract_function_params(right, source));
 
                             let full_name = format!("{}.{}", service_name, method_name);
-                            let span = Span::new(
-                                self.offset_line(start.row as u32),
-                                start.column as u32,
-                                self.offset_line(end.row as u32),
-                                end.column as u32,
-                            );
+                            let span = self.span_of(property);
 
                             let mut builder = SymbolBuilder::new(full_name, SymbolKind::Method, uri.clone())
                                 .definition_span(span)
@@ -506,30 +468,16 @@ impl AngularJsAnalyzer {
                             let method_name = self.node_text(key, source);
                             let full_name = format!("{}.{}", service_name, method_name);
                             // シンボル名の位置はキーの位置
-                            let name_start = key.start_position();
-                            let name_end = key.end_position();
-                            let name_span = Span::new(
-                                self.offset_line(name_start.row as u32),
-                                name_start.column as u32,
-                                self.offset_line(name_end.row as u32),
-                                name_end.column as u32,
-                            );
+                            let name_span = self.span_of(key);
 
                             match value.kind() {
                                 // 直接関数定義: login: function() {}
                                 "function_expression" | "arrow_function" => {
-                                    let start = key.start_position();
-                                    let end = key.end_position();
                                     // pairノードの行からJSDocを探す
                                     let docs = self.extract_jsdoc_for_line(child.start_position().row, source);
                                     // パラメータを抽出
                                     let parameters = self.extract_function_params(value, source);
-                                    let def_span = Span::new(
-                                        self.offset_line(start.row as u32),
-                                        start.column as u32,
-                                        self.offset_line(end.row as u32),
-                                        end.column as u32,
-                                    );
+                                    let def_span = self.span_of(key);
 
                                     let mut builder = SymbolBuilder::new(full_name, SymbolKind::Method, uri.clone())
                                         .definition_span(def_span)
@@ -563,15 +511,8 @@ impl AngularJsAnalyzer {
                                         self.index.definitions.add_definition(builder.build());
                                     } else {
                                         // ローカル変数が見つからない場合はキーの位置を使用
-                                        let start = key.start_position();
-                                        let end = key.end_position();
                                         let docs = self.extract_jsdoc_for_line(child.start_position().row, source);
-                                        let def_span = Span::new(
-                                            self.offset_line(start.row as u32),
-                                            start.column as u32,
-                                            self.offset_line(end.row as u32),
-                                            end.column as u32,
-                                        );
+                                        let def_span = self.span_of(key);
 
                                         let mut builder = SymbolBuilder::new(full_name, SymbolKind::Method, uri.clone())
                                             .definition_span(def_span)
@@ -594,14 +535,7 @@ impl AngularJsAnalyzer {
                     let method_name = self.node_text(child, source);
                     let full_name = format!("{}.{}", service_name, method_name);
                     // シンボル名の位置はshorthandプロパティの位置
-                    let name_start = child.start_position();
-                    let name_end = child.end_position();
-                    let name_span = Span::new(
-                        self.offset_line(name_start.row as u32),
-                        name_start.column as u32,
-                        self.offset_line(name_end.row as u32),
-                        name_end.column as u32,
-                    );
+                    let name_span = self.span_of(child);
 
                     // ローカル変数の定義位置があればそれを使用
                     if let Some(loc) = local_vars.get(&method_name) {
@@ -618,15 +552,8 @@ impl AngularJsAnalyzer {
 
                         self.index.definitions.add_definition(builder.build());
                     } else {
-                        let start = child.start_position();
-                        let end = child.end_position();
-                        let docs = self.extract_jsdoc_for_line(start.row, source);
-                        let def_span = Span::new(
-                            self.offset_line(start.row as u32),
-                            start.column as u32,
-                            self.offset_line(end.row as u32),
-                            end.column as u32,
-                        );
+                        let docs = self.extract_jsdoc_for_line(child.start_position().row, source);
+                        let def_span = self.span_of(child);
 
                         let mut builder = SymbolBuilder::new(full_name, SymbolKind::Method, uri.clone())
                             .definition_span(def_span)
@@ -799,8 +726,6 @@ impl AngularJsAnalyzer {
                     if is_this_or_alias {
                         if let Some(property) = left.child_by_field_name("property") {
                             let method_name = self.node_text(property, source);
-                            let start = property.start_position();
-                            let end = property.end_position();
 
                             let docs = self.extract_jsdoc_for_line(assign_node.start_position().row, source);
 
@@ -810,12 +735,7 @@ impl AngularJsAnalyzer {
                                 .and_then(|right| self.extract_function_params(right, source));
 
                             let full_name = format!("{}.{}", controller_name, method_name);
-                            let span = Span::new(
-                                self.offset_line(start.row as u32),
-                                start.column as u32,
-                                self.offset_line(end.row as u32),
-                                end.column as u32,
-                            );
+                            let span = self.span_of(property);
 
                             let mut builder = SymbolBuilder::new(full_name, SymbolKind::Method, uri.clone())
                                 .definition_span(span)


### PR DESCRIPTION
Add `AngularJsAnalyzer::span_of(node)` and replace ~46 inline copies of
the 4-line `Span::new(self.offset_line(start.row as u32), ...)` pattern
across `src/analyzer/js/{di,reference,scope,service_method,component,export}.rs`.

Net: -253 lines. Closes #45.

Two call sites are intentionally left as-is:
- `export.rs:128` adjusts columns by ±1 to strip string-literal quotes;
  doesn't fit the helper's semantics.
- `component.rs:846` builds a span from `tree_sitter::Point` tuples
  returned by `find_function_position`, not from a `Node`.

https://claude.ai/code/session_01DCFMruWtGYVp4Zuzx8Mr57