### PR TITLE
refactor: `scope_reference.rs` から ui-sref / ng-model 処理を別モジュールへ分離 (#48)

### DIFF
--- a/src/analyzer/html/mod.rs
+++ b/src/analyzer/html/mod.rs
@@ -14,9 +14,11 @@ pub mod expression;
 pub mod form;
 pub mod local_variable;
 pub mod ng_include;
+pub mod ng_model;
 pub mod parser;
 pub mod scope_reference;
 pub mod script;
+pub mod ui_sref;
 pub mod variable_parser;
 
 use controller::ControllerScopeInfo;

--- a/src/analyzer/html/ng_model.rs
+++ b/src/analyzer/html/ng_model.rs
@@ -1,0 +1,36 @@
+//! `ng-model` の暗黙的な `$scope` 定義収集
+//!
+//! `<input ng-model="user.name">` は `$scope.user.name` への双方向書き込みを生むので、
+//! controller 側で `$scope.user.name = ...` を書いていなくても診断で「未定義」と判定
+//! しないように、テンプレート側で暗黙的な定義として記録する。
+//!
+//! `$scope` 参照収集 (`scope_reference.rs`) とは責務が別なので独立モジュールに分離
+//! している (issue #48)。
+
+use tower_lsp::lsp_types::Url;
+
+use crate::model::HtmlNgModelTarget;
+
+use super::HtmlAngularJsAnalyzer;
+
+impl HtmlAngularJsAnalyzer {
+    /// `ng-model="X"` の値 `X` を `$scope` への暗黙的な書き込み定義として登録する。
+    pub(super) fn register_ng_model_target(
+        &self,
+        uri: &Url,
+        value: &str,
+        value_start_line: u32,
+        value_start_col: u32,
+    ) {
+        let len_utf16 = value.chars().map(|c| c.len_utf16()).sum::<usize>() as u32;
+        let target = HtmlNgModelTarget {
+            property_path: value.to_string(),
+            uri: uri.clone(),
+            start_line: value_start_line,
+            start_col: value_start_col,
+            end_line: value_start_line,
+            end_col: value_start_col + len_utf16,
+        };
+        self.index.html.add_ng_model_target(target);
+    }
+}

--- a/src/analyzer/html/scope_reference.rs
+++ b/src/analyzer/html/scope_reference.rs
@@ -4,7 +4,7 @@ use tower_lsp::lsp_types::Url;
 use tree_sitter::Node;
 
 use super::directives::{is_directive_attribute, is_literal_value_directive};
-use crate::model::{HtmlNgModelTarget, HtmlScopeReference, HtmlUiSrefReference, Span, SymbolReference};
+use crate::model::HtmlScopeReference;
 
 use super::HtmlAngularJsAnalyzer;
 
@@ -83,21 +83,17 @@ impl HtmlAngularJsAnalyzer {
                             let property_paths = self.parse_angular_expression(value, &attr_name);
                             self.register_scope_references(uri, value, &property_paths, value_start_line as u32, value_start_col);
 
-                            // ng-model="X" の値は \$scope への書き込みを行うので、
-                            // 暗黙的な scope property 定義として記録する
+                            // ng-model="X" は $scope への暗黙的書き込みを生むので、
+                            // テンプレート側で定義として記録する
                             // (controller 側で `$scope.X = ...` を書かなくても診断で
                             //  「未定義」と判定されないようにするため)
                             if attr_name == "ng-model" || attr_name == "data-ng-model" {
-                                let target = HtmlNgModelTarget {
-                                    property_path: value.to_string(),
-                                    uri: uri.clone(),
-                                    start_line: value_start_line as u32,
-                                    start_col: value_start_col,
-                                    end_line: value_start_line as u32,
-                                    end_col: value_start_col
-                                        + value.chars().map(|c| c.len_utf16()).sum::<usize>() as u32,
-                                };
-                                self.index.html.add_ng_model_target(target);
+                                self.register_ng_model_target(
+                                    uri,
+                                    value,
+                                    value_start_line as u32,
+                                    value_start_col,
+                                );
                             }
                         } else {
                             // 非ディレクティブ属性 または リテラル値ディレクティブ:
@@ -178,62 +174,6 @@ impl HtmlAngularJsAnalyzer {
                 self.index.html.add_html_scope_reference(html_reference);
             }
         }
-    }
-
-    /// `ui-sref="state-name[(...args)]"` の state 名部分を `HtmlUiSrefReference` と
-    /// `SymbolReference` の両方として登録する。
-    ///
-    /// 値の形式:
-    /// - `home` → state 名 = "home"
-    /// - `home.detail` → state 名 = "home.detail" (dot-notation 子 state)
-    /// - `home({id: 1})` → state 名 = "home" (引数部分は無視)
-    ///
-    /// 以下はスキップ:
-    /// - 空文字列
-    /// - 相対参照 (`.`, `^`, `^.foo` など) — state 名解決に親 state コンテキストが必要
-    fn register_ui_sref_reference(
-        &self,
-        uri: &Url,
-        value: &str,
-        value_start_line: u32,
-        value_start_col: u32,
-    ) {
-        // 引数部分 `(...)` の前までを state 名として切り出す
-        let name_part = value.split('(').next().unwrap_or(value);
-        let trimmed = name_part.trim();
-        if trimmed.is_empty() {
-            return;
-        }
-
-        // ui-router の相対参照は今は解決対象外
-        if trimmed == "." || trimmed.starts_with('^') {
-            return;
-        }
-
-        // 先頭の空白文字数だけ start_col をずらす
-        let leading_whitespace_bytes = name_part.len() - name_part.trim_start().len();
-        let utf16_leading = self.byte_offset_to_utf16_offset(name_part, leading_whitespace_bytes) as u32;
-        let start_col = value_start_col + utf16_leading;
-        let len_utf16 = trimmed.chars().map(|c| c.len_utf16()).sum::<usize>() as u32;
-        let end_col = start_col + len_utf16;
-
-        let reference = HtmlUiSrefReference {
-            state_name: trimmed.to_string(),
-            uri: uri.clone(),
-            start_line: value_start_line,
-            start_col,
-            end_line: value_start_line,
-            end_col,
-        };
-        self.index.html.add_ui_sref_reference(reference);
-
-        // 既存の find-references インフラ用に SymbolReference も登録する
-        // (これにより state 定義からの find-references で HTML 側の使用箇所も列挙される)
-        self.index.definitions.add_reference(SymbolReference {
-            name: trimmed.to_string(),
-            uri: uri.clone(),
-            span: Span::new(value_start_line, start_col, value_start_line, end_col),
-        });
     }
 
     /// 属性値内のインターポレーションからスコープ参照を抽出（UTF-16対応）

--- a/src/analyzer/html/ui_sref.rs
+++ b/src/analyzer/html/ui_sref.rs
@@ -1,0 +1,70 @@
+//! `ui-sref` (ui-router) 属性値からの state 名参照収集
+//!
+//! ui-router は `<a ui-sref="home">` のようにテンプレートから state へジャンプするので、
+//! state 名を参照として登録しておくことで goto-definition / find-references が機能する。
+//!
+//! `$scope` 参照とは独立した責務なので独立モジュールに分離している (issue #48)。
+
+use tower_lsp::lsp_types::Url;
+
+use crate::model::{HtmlUiSrefReference, Span, SymbolReference};
+
+use super::HtmlAngularJsAnalyzer;
+
+impl HtmlAngularJsAnalyzer {
+    /// `ui-sref="state-name[(...args)]"` の state 名部分を `HtmlUiSrefReference` と
+    /// `SymbolReference` の両方として登録する。
+    ///
+    /// 値の形式:
+    /// - `home` → state 名 = "home"
+    /// - `home.detail` → state 名 = "home.detail" (dot-notation 子 state)
+    /// - `home({id: 1})` → state 名 = "home" (引数部分は無視)
+    ///
+    /// 以下はスキップ:
+    /// - 空文字列
+    /// - 相対参照 (`.`, `^`, `^.foo` など) — state 名解決に親 state コンテキストが必要
+    pub(super) fn register_ui_sref_reference(
+        &self,
+        uri: &Url,
+        value: &str,
+        value_start_line: u32,
+        value_start_col: u32,
+    ) {
+        // 引数部分 `(...)` の前までを state 名として切り出す
+        let name_part = value.split('(').next().unwrap_or(value);
+        let trimmed = name_part.trim();
+        if trimmed.is_empty() {
+            return;
+        }
+
+        // ui-router の相対参照は今は解決対象外
+        if trimmed == "." || trimmed.starts_with('^') {
+            return;
+        }
+
+        // 先頭の空白文字数だけ start_col をずらす
+        let leading_whitespace_bytes = name_part.len() - name_part.trim_start().len();
+        let utf16_leading = self.byte_offset_to_utf16_offset(name_part, leading_whitespace_bytes) as u32;
+        let start_col = value_start_col + utf16_leading;
+        let len_utf16 = trimmed.chars().map(|c| c.len_utf16()).sum::<usize>() as u32;
+        let end_col = start_col + len_utf16;
+
+        let reference = HtmlUiSrefReference {
+            state_name: trimmed.to_string(),
+            uri: uri.clone(),
+            start_line: value_start_line,
+            start_col,
+            end_line: value_start_line,
+            end_col,
+        };
+        self.index.html.add_ui_sref_reference(reference);
+
+        // 既存の find-references インフラ用に SymbolReference も登録する
+        // (これにより state 定義からの find-references で HTML 側の使用箇所も列挙される)
+        self.index.definitions.add_reference(SymbolReference {
+            name: trimmed.to_string(),
+            uri: uri.clone(),
+            span: Span::new(value_start_line, start_col, value_start_line, end_col),
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- \`src/analyzer/html/scope_reference.rs\` がファイル名の責務 (\$scope 参照収集) を超えて ui-router の \`ui-sref\` state 名参照と \`ng-model\` の暗黙的 \$scope 定義も処理していたため、責務ごとにモジュールを分離
- 新規: \`src/analyzer/html/ui_sref.rs\` (state 名参照登録)
- 新規: \`src/analyzer/html/ng_model.rs\` (\`HtmlNgModelTarget\` 登録)
- \`scope_reference.rs\` 側は両ヘルパーを呼ぶだけのディスパッチに

## 意味的明瞭性
- ファイルを開いた瞬間に何を扱っているかが分かる
- 新しい属性 (例: \`track-by\`) 対応を追加するときの場所が明確
- 既存の \`directive_reference.rs\` / \`form.rs\` と同じ「責務単位」の組織化に揃う

## Test plan
- [x] \`cargo build\` が通る (挙動変更なし、移動のみ)
- [x] lib 161 / integration 148 / investigate 2 すべて通過

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)