### PR TITLE
perf: `did_open` / `initialized` 後の `semantic_tokens_refresh` を診断発行と並列化

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -608,19 +608,25 @@ impl Backend {
             }
         }
 
-        // 2. 全 open file の診断を再発行 (HTML + JS)
-        for (uri, _) in &open_files {
-            if is_html_file(uri) {
-                self.publish_diagnostics_for_html(uri).await;
-            } else if is_js_file(uri) {
-                self.publish_diagnostics_for_js(uri).await;
+        // 2. 全 open file の診断を再発行 (HTML + JS) と refresh signal を並列化。
+        //    診断発行ループは open files 数に比例するので、refresh を直列に置くと
+        //    ハイライト復帰が遅れる。両者とも index は populate 済みで互いに独立。
+        let diagnostics = async {
+            for (uri, _) in &open_files {
+                if is_html_file(uri) {
+                    self.publish_diagnostics_for_html(uri).await;
+                } else if is_js_file(uri) {
+                    self.publish_diagnostics_for_js(uri).await;
+                }
             }
-        }
-
-        // 3. semanticTokens / codeLens refresh 発火 (クライアント側に全 open file
-        //    分の再要求をさせる)
-        let _ = self.client.semantic_tokens_refresh().await;
-        let _ = self.client.code_lens_refresh().await;
+        };
+        let refresh_signals = async {
+            // semanticTokens / codeLens refresh 発火 (クライアント側に全 open file
+            // 分の再要求をさせる)
+            let _ = self.client.semantic_tokens_refresh().await;
+            let _ = self.client.code_lens_refresh().await;
+        };
+        tokio::join!(diagnostics, refresh_signals);
     }
 
     async fn on_change(&self, uri: Url, text: String) {
@@ -874,14 +880,23 @@ impl Backend {
             .await
             .unwrap_or(());
 
-            self.publish_diagnostics_for_html(&uri).await;
-            self.republish_diagnostics_for_open_js_files().await;
-
-            // クライアントが on_open 完了前に semantic_tokens_full を要求した場合、
-            // 空トークンが返ってハイライトが永続的に消えるレースを防ぐ。
-            // 解析完了をクライアントに通知して再要求させる。
-            let _ = self.client.semantic_tokens_refresh().await;
-            let _ = self.client.code_lens_refresh().await;
+            // 解析完了後、診断発行と semantic_tokens / code_lens の refresh signal を
+            // 並列に走らせる。診断発行は IPC + (republish 内では) CPU 解析を含むので
+            // 直列にすると refresh signal がその分遅れ、エディタのハイライト復帰が遅延する。
+            // 双方とも index 完成 (= spawn_blocking 完了) のみが事前条件で互いに依存しない。
+            //
+            // refresh signal の意味は変わらず: クライアントが on_open 完了前に
+            // `semantic_tokens_full` を要求して空トークンを得てしまうレースを潰す
+            // (解析完了を通知して再要求させる)。
+            let refresh_signals = async {
+                let _ = self.client.semantic_tokens_refresh().await;
+                let _ = self.client.code_lens_refresh().await;
+            };
+            let diagnostics = async {
+                self.publish_diagnostics_for_html(&uri).await;
+                self.republish_diagnostics_for_open_js_files().await;
+            };
+            tokio::join!(refresh_signals, diagnostics);
         } else if is_js_file(&uri) {
             self.debounce_versions.insert(uri.clone(), 0);
 
@@ -894,11 +909,13 @@ impl Backend {
             .await
             .unwrap_or(());
 
-            self.publish_diagnostics_for_js(&uri).await;
-
-            // (HTML側と同じ理由) JS ファイルでも解析後に refresh を送る
-            let _ = self.client.semantic_tokens_refresh().await;
-            let _ = self.client.code_lens_refresh().await;
+            // (HTML側と同じ理由で並列化) refresh signal と診断発行は互いに独立
+            let refresh_signals = async {
+                let _ = self.client.semantic_tokens_refresh().await;
+                let _ = self.client.code_lens_refresh().await;
+            };
+            let diagnostics = self.publish_diagnostics_for_js(&uri);
+            tokio::join!(refresh_signals, diagnostics);
         }
 
         // tsserver は JS ファイルだけ知っていれば良い (HTML は内部ハンドラで処理)


### PR DESCRIPTION
## Summary
ファイルを開いた際のセマンティックハイライト復帰までの latency を短縮。

これまで \`on_open\` / \`republish_open_files_after_init\` で「解析 → 診断発行 → refresh signal」が直列に並んでおり、診断発行 (特に open JS 数に比例する \`republish_diagnostics_for_open_js_files\` ループ) の完了まで \`semantic_tokens_refresh\` が送られず、エディタのハイライト復帰が遅延していた。

\`spawn_blocking\` 完了 (= index populate 済み) 後は、診断発行と refresh signal は互いに独立に進められるので \`tokio::join!\` で並列化する。クライアントは診断計算を待たずに新しい token を取りに来れる。

## 変更箇所 (\`src/server/mod.rs\`)
- \`on_open\` HTML branch: \`publish_diagnostics_for_html\` + \`republish_diagnostics_for_open_js_files\` と refresh signal を並列化
- \`on_open\` JS branch: \`publish_diagnostics_for_js\` と refresh signal を並列化
- \`republish_open_files_after_init\` (initialized 後): open files 全体の診断ループと refresh signal を並列化

\`on_change\` 経路は cross-file dep snapshot に応じた conditional refresh があり構造が異なるため、本 PR の対象外。

## 挙動変更なし
\`semantic_tokens_refresh\` の事前条件は依然 index populate 済み (= 解析 spawn_blocking 完了後)。発火順だけが変わる。

## Test plan
- [x] \`cargo build\` が通る (新規 warning なし)
- [x] lib 172 / integration 148 / investigate 2 すべて通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)