### PR TITLE
feat: signature help (#70)

### DIFF
--- a/tests/signature_help_test.rs
+++ b/tests/signature_help_test.rs
@@ -1,0 +1,139 @@
+///! signatureHelp ハンドラの統合テスト。
+///!
+///! AngularJS のシンボル (controller method, service method, factory method) の
+///! 引数ヒントを LSP signatureHelp として返せるかを検証する。
+
+use std::sync::Arc;
+use tower_lsp::lsp_types::{ParameterLabel, Url};
+
+use angularjs_lsp::analyzer::js::AngularJsAnalyzer;
+use angularjs_lsp::handler::SignatureHelpHandler;
+use angularjs_lsp::index::Index;
+
+/// JS ソースを 1 ファイル解析した index と uri を返すヘルパー。
+fn analyze_js_source(source: &str) -> (Arc<Index>, Url) {
+    let index = Arc::new(Index::new());
+    let analyzer = AngularJsAnalyzer::new(Arc::clone(&index));
+    let uri = Url::parse("file:///test.js").unwrap();
+    analyzer.analyze_document(&uri, source);
+    (index, uri)
+}
+
+#[test]
+fn signature_help_for_service_method_call_in_js() {
+    // .service('UserService', function() { this.update = function(user, opts) {} })
+    // を解析してから、別ファイル風に同じソース内の "UserService.update(<cursor>" の
+    // 位置で signatureHelp を要求する。
+    let source = r#"
+angular.module('app', [])
+.service('UserService', function() {
+    this.update = function(user, opts) {};
+});
+
+function callIt() {
+    UserService.update();
+}
+"#;
+    let (index, uri) = analyze_js_source(source);
+
+    // "UserService.update(" の `(` の直後 (開き括弧の中) にカーソルがある状態を作る
+    // 8 行目: "    UserService.update();" — 0-indexed の 7
+    // `(` の位置を特定して直後にカーソルを置く
+    let line_text = "    UserService.update();";
+    let paren_pos = line_text.find('(').unwrap() as u32 + 1;
+
+    let handler = SignatureHelpHandler::new(index);
+    let help = handler
+        .signature_help(&uri, 7, paren_pos, source)
+        .expect("signature help が返るべき (service method)");
+
+    assert_eq!(help.signatures.len(), 1, "signature が 1 つ");
+    let sig = &help.signatures[0];
+    assert!(
+        sig.label.contains("update"),
+        "label にメソッド名が入る: {}",
+        sig.label
+    );
+    let params = sig.parameters.as_ref().expect("parameters があるべき");
+    let names: Vec<String> = params
+        .iter()
+        .map(|p| match &p.label {
+            ParameterLabel::Simple(s) => s.clone(),
+            ParameterLabel::LabelOffsets(_) => String::new(),
+        })
+        .collect();
+    assert_eq!(names, vec!["user".to_string(), "opts".to_string()]);
+    assert_eq!(help.active_parameter, Some(0));
+}
+
+#[test]
+fn signature_help_for_service_method_active_parameter_after_comma() {
+    // 第1引数の後 (カンマの後) にカーソルがある場合、active_parameter は 1。
+    let source = r#"
+angular.module('app', [])
+.service('UserService', function() {
+    this.update = function(user, opts) {};
+});
+
+function callIt() {
+    UserService.update(currentUser, );
+}
+"#;
+    let (index, uri) = analyze_js_source(source);
+
+    // 8 行目 (0-indexed 7): "    UserService.update(currentUser, );"
+    // カンマの後ろ・スペースの位置にカーソル
+    let line_text = "    UserService.update(currentUser, );";
+    let comma_pos = line_text.find(", ").unwrap() as u32 + 2; // ", " の後ろ
+
+    let handler = SignatureHelpHandler::new(index);
+    let help = handler
+        .signature_help(&uri, 7, comma_pos, source)
+        .expect("signature help が返るべき");
+
+    assert_eq!(help.active_parameter, Some(1), "第2引数位置を示す");
+    assert_eq!(help.signatures[0].active_parameter, Some(1));
+}
+
+#[test]
+fn signature_help_returns_none_when_symbol_has_no_parameters() {
+    // controller / service として登録されたシンボル (Component / Module 等) は
+    // parameters: None のため、signatureHelp は None を返す。
+    let source = r#"
+angular.module('myApp', []);
+
+function caller() {
+    myApp();
+}
+"#;
+    let (index, uri) = analyze_js_source(source);
+
+    let line_text = "    myApp();";
+    let paren_pos = line_text.find('(').unwrap() as u32 + 1;
+
+    let handler = SignatureHelpHandler::new(index);
+    let help = handler.signature_help(&uri, 4, paren_pos, source);
+
+    assert!(
+        help.is_none(),
+        "引数情報のないシンボルでは signatureHelp は None"
+    );
+}
+
+#[test]
+fn signature_help_returns_none_when_no_call_context() {
+    // 関数呼び出しの括弧外にカーソルがある場合は None。
+    let source = r#"
+angular.module('app', [])
+.service('UserService', function() {
+    this.update = function(user) {};
+});
+"#;
+    let (index, uri) = analyze_js_source(source);
+
+    // 1 行目 (空行) の col 0 にカーソル
+    let handler = SignatureHelpHandler::new(index);
+    let help = handler.signature_help(&uri, 0, 0, source);
+
+    assert!(help.is_none(), "呼び出し外では signatureHelp は None");
+}


### PR DESCRIPTION
## Summary
- LSP `textDocument/signatureHelp` を AngularJS のシンボル (controller method, service method, factory method) 用に提供する機能 (issue #70) を、エンドツーエンド統合テストで保証する。
- 実装本体 (`src/handler/signature_help.rs` / `Symbol::parameters` / `SymbolBuilder::parameters` / `SignatureHelpOptions` capability + `signature_help` async ハンドラ) は既に master に存在しているため、本 PR では動作保証のための統合テストを 4 件追加する。
- テスト追加により `cargo test` / `cargo build` ともに警告ゼロで通過することを確認した。

## 実装範囲
- 既存実装の確認:
  - `src/handler/signature_help.rs`: 開き括弧/カンマからの active_parameter 計算、`ServiceName.method` および `$scope.method` / HTML alias.method / template-resolved controller の解決、`SignatureInformation` 構築。
  - `src/model/symbol.rs`: `Symbol::parameters: Option<Vec<String>>`。
  - `src/model/builder.rs`: `SymbolBuilder::parameters(Vec<String>)` setter。
  - `src/analyzer/js/service_method.rs`: `this.X = function(...)` / class method / object literal `key: function(...)` / `returnedVar.method = ...` 等から `extract_function_params` で param 名リストを抽出して Symbol に保存。
  - `src/server/mod.rs`: `signature_help_provider: Some(SignatureHelpOptions { trigger_characters: ['(', ','], ... })` capability + `async fn signature_help` 実装。
- 本 PR で追加した統合テスト (`tests/signature_help_test.rs`):
  1. `signature_help_for_service_method_call_in_js`: `.service('UserService', function() { this.update = function(user, opts) {} })` を解析後、`UserService.update(<cursor>` 位置で `update(user, opts)` の SignatureHelp が返ることを検証 (label / parameter labels / active_parameter=0)。
  2. `signature_help_for_service_method_active_parameter_after_comma`: `UserService.update(currentUser, <cursor> )` のとき `active_parameter == Some(1)` を検証。
  3. `signature_help_returns_none_when_symbol_has_no_parameters`: `parameters` を持たないシンボル (Module 等) では `None` を返し、不適切なポップアップを出さないことを検証。
  4. `signature_help_returns_none_when_no_call_context`: 関数呼び出し外 (空行) では `None` を返す。

## 範囲外 (将来 issue)
- HTML テンプレート (`{{ vm.doSomething(arg1, ` のような補間内呼び出し) の signatureHelp。実装側のロジックは入っているが本 PR では JS のみテスト。
- JSDoc `@param` 解析による各引数の説明文付与 (issue #70 本文でも将来扱いと明記)。

## Test plan
- [x] `cargo build` 警告ゼロ
- [x] `cargo test --test signature_help_test` 4/4 通過
- [x] `cargo test` 全通過 (lib 172 + integration 148 + investigate 2 + 新規 4)
- [ ] 実エディタ (VS Code 等) の AngularJS プロジェクトで `service.method(` の入力時に signatureHelp が出ることを目視確認

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)