### PR TITLE
diagnostic: 存在しない ui-router state 名を警告 (#61)

### DIFF
--- a/src/analyzer/js/component.rs
+++ b/src/analyzer/js/component.rs
@@ -4,8 +4,8 @@ use tree_sitter::Node;
 use super::context::{AnalyzerContext, DiScope};
 use super::AngularJsAnalyzer;
 use crate::model::{
-    BindingSource, ComponentTemplateUrl, ControllerScope, Span, SymbolBuilder, SymbolKind,
-    SymbolReference, TemplateBinding,
+    BindingSource, ComponentTemplateUrl, ControllerScope, JsStateNavigationReference, Span,
+    SymbolBuilder, SymbolKind, SymbolReference, TemplateBinding,
 };
 
 impl AngularJsAnalyzer {
@@ -608,6 +608,8 @@ impl AngularJsAnalyzer {
     /// `SymbolReference` として登録する。
     ///
     /// 文字列リテラル以外 (動的式) は state 名を解決できないので無視する。
+    /// 相対参照 (`.`, `^.foo` など) は state 解決に親 state コンテキストが必要なので
+    /// 診断インデックスにも登録しない (false positive 防止)。
     fn extract_state_navigation_reference(&self, node: Node, source: &str, uri: &Url) {
         let args = match node.child_by_field_name("arguments") {
             Some(a) => a,
@@ -621,11 +623,24 @@ impl AngularJsAnalyzer {
             return;
         }
         let state_name = self.extract_string_value(first_arg, source);
+        let span = self.span_of(first_arg);
         self.index.definitions.add_reference(SymbolReference {
-            name: state_name,
+            name: state_name.clone(),
             uri: uri.clone(),
-            span: self.span_of(first_arg),
+            span,
         });
+
+        // 診断 (未登録 state 警告) 用の URI 別インデックスにも登録する。
+        // 相対参照は親 state を解決しないと正しく warning 出せないので除外する。
+        if !state_name.is_empty() && state_name != "." && !state_name.starts_with('^') {
+            self.index
+                .definitions
+                .add_js_state_navigation_reference(JsStateNavigationReference {
+                    state_name,
+                    uri: uri.clone(),
+                    span,
+                });
+        }
     }
 
     /// `views: { 'name': { controller, templateUrl, ... }, ... }` の各ビュー設定を処理する

--- a/src/config/ajs_config.rs
+++ b/src/config/ajs_config.rs
@@ -40,6 +40,15 @@ pub struct DiagnosticsConfig {
     /// 未使用スコープ変数の警告を有効にする（デフォルト: true）
     #[serde(default = "default_true")]
     pub unused_scope_variables: bool,
+    /// 未登録の ui-router state を `ui-sref` / `$state.go` で参照した場合の重要度。
+    /// "error" / "warning" / "hint" / "information" / "off"（デフォルト: "warning"）
+    ///
+    /// "off" を指定すると本診断は出力されない。
+    ///
+    /// TODO: 将来的には `external_states` のような allowlist を導入し、
+    /// プロジェクト外で定義される (lazy-loaded module 等の) state を許容する。
+    #[serde(default = "default_unknown_state_severity")]
+    pub unknown_state_severity: String,
 }
 
 fn default_true() -> bool {
@@ -50,12 +59,17 @@ fn default_severity() -> String {
     "warning".to_string()
 }
 
+fn default_unknown_state_severity() -> String {
+    "warning".to_string()
+}
+
 impl Default for DiagnosticsConfig {
     fn default() -> Self {
         Self {
             enabled: default_true(),
             severity: default_severity(),
             unused_scope_variables: default_true(),
+            unknown_state_severity: default_unknown_state_severity(),
         }
     }
 }
@@ -158,5 +172,18 @@ mod tests {
         assert!(config.enabled);
         assert_eq!(config.severity, "warning");
         assert!(config.unused_scope_variables);
+        assert_eq!(config.unknown_state_severity, "warning");
+    }
+
+    #[test]
+    fn test_diagnostics_unknown_state_severity_off() {
+        // "off" を指定すれば後段で診断スキップに使える文字列として読み込めること
+        let json = r#"{
+            "diagnostics": {
+                "unknown_state_severity": "off"
+            }
+        }"#;
+        let config: AjsConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.diagnostics.unknown_state_severity, "off");
     }
 }

--- a/src/handler/diagnostics.rs
+++ b/src/handler/diagnostics.rs
@@ -5,6 +5,7 @@ use tracing::debug;
 
 use crate::config::DiagnosticsConfig;
 use crate::index::Index;
+use crate::model::SymbolKind;
 
 /// 診断ハンドラー
 pub struct DiagnosticsHandler {
@@ -28,6 +29,19 @@ impl DiagnosticsHandler {
         }
     }
 
+    /// 未登録 state 用 severity を解決。"off" の場合は `None` を返し、
+    /// 呼び出し側で診断スキップを判断する。
+    fn parse_unknown_state_severity(&self) -> Option<DiagnosticSeverity> {
+        match self.config.unknown_state_severity.to_lowercase().as_str() {
+            "off" | "none" => None,
+            "error" => Some(DiagnosticSeverity::ERROR),
+            "warning" => Some(DiagnosticSeverity::WARNING),
+            "hint" => Some(DiagnosticSeverity::HINT),
+            "information" | "info" => Some(DiagnosticSeverity::INFORMATION),
+            _ => Some(DiagnosticSeverity::WARNING),
+        }
+    }
+
     /// HTMLファイルの診断を実行
     pub fn diagnose_html(&self, uri: &Url) -> Vec<Diagnostic> {
         if !self.config.enabled {
@@ -41,6 +55,9 @@ impl DiagnosticsHandler {
 
         // ローカル変数参照のチェック
         diagnostics.extend(self.check_local_variable_references(uri));
+
+        // 未登録 ui-router state 名 (ui-sref) のチェック
+        diagnostics.extend(self.check_unknown_state_names_html(uri));
 
         diagnostics
     }
@@ -58,7 +75,139 @@ impl DiagnosticsHandler {
             diagnostics.extend(self.check_unused_scope_variables(uri));
         }
 
+        // 未登録 ui-router state 名 ($state.go / $state.transitionTo) のチェック
+        diagnostics.extend(self.check_unknown_state_names_js(uri));
+
         diagnostics
+    }
+
+    /// HTML 内の `ui-sref="state-name"` 参照のうち、workspace 内に対応する
+    /// `$stateProvider.state(...)` 定義が存在しないものを警告として返す。
+    ///
+    /// state 定義が一切登録されていない workspace では false positive を避けるため
+    /// 全参照について警告を抑制する (state ファイルがまだ解析されていない可能性が
+    /// あり、例えばシングルファイル編集時など)。
+    fn check_unknown_state_names_html(&self, uri: &Url) -> Vec<Diagnostic> {
+        let Some(severity) = self.parse_unknown_state_severity() else {
+            return Vec::new();
+        };
+        let mut diagnostics = Vec::new();
+
+        // workspace に state 定義が一つも無ければ false positive を避けるため何も出さない
+        if !self.workspace_has_any_state_definition() {
+            return diagnostics;
+        }
+
+        let references = self.index.html.get_ui_sref_references_for_uri(uri);
+        debug!(
+            "check_unknown_state_names_html: uri={}, ref_count={}",
+            uri,
+            references.len()
+        );
+
+        for reference in references {
+            if !self
+                .index
+                .definitions
+                .has_definition_of_kind(&reference.state_name, SymbolKind::UiRouterState)
+            {
+                diagnostics.push(Diagnostic {
+                    range: Range {
+                        start: Position {
+                            line: reference.start_line,
+                            character: reference.start_col,
+                        },
+                        end: Position {
+                            line: reference.end_line,
+                            character: reference.end_col,
+                        },
+                    },
+                    severity: Some(severity),
+                    code: None,
+                    code_description: None,
+                    source: Some("angularjs-lsp".to_string()),
+                    message: format!(
+                        "Unknown ui-router state '{}' (no matching $stateProvider.state(...) definition)",
+                        reference.state_name
+                    ),
+                    related_information: None,
+                    tags: None,
+                    data: None,
+                });
+            }
+        }
+
+        diagnostics
+    }
+
+    /// JS 内の `$state.go('state-name')` / `$state.transitionTo('state-name')`
+    /// 参照のうち、workspace 内に対応する state 定義が無いものを警告として返す。
+    fn check_unknown_state_names_js(&self, uri: &Url) -> Vec<Diagnostic> {
+        let Some(severity) = self.parse_unknown_state_severity() else {
+            return Vec::new();
+        };
+        let mut diagnostics = Vec::new();
+
+        if !self.workspace_has_any_state_definition() {
+            return diagnostics;
+        }
+
+        let references = self
+            .index
+            .definitions
+            .get_js_state_navigation_references_for_uri(uri);
+        debug!(
+            "check_unknown_state_names_js: uri={}, ref_count={}",
+            uri,
+            references.len()
+        );
+
+        for reference in references {
+            if !self
+                .index
+                .definitions
+                .has_definition_of_kind(&reference.state_name, SymbolKind::UiRouterState)
+            {
+                diagnostics.push(Diagnostic {
+                    range: Range {
+                        start: Position {
+                            line: reference.span.start_line,
+                            character: reference.span.start_col,
+                        },
+                        end: Position {
+                            line: reference.span.end_line,
+                            character: reference.span.end_col,
+                        },
+                    },
+                    severity: Some(severity),
+                    code: None,
+                    code_description: None,
+                    source: Some("angularjs-lsp".to_string()),
+                    message: format!(
+                        "Unknown ui-router state '{}' (no matching $stateProvider.state(...) definition)",
+                        reference.state_name
+                    ),
+                    related_information: None,
+                    tags: None,
+                    data: None,
+                });
+            }
+        }
+
+        diagnostics
+    }
+
+    /// workspace 全体に `$stateProvider.state(...)` 由来の定義が 1 件でもあるか。
+    ///
+    /// 何も解析されていない / ui-router を使っていないプロジェクトでは
+    /// 全 ui-sref / `$state.go` 参照に false positive が出るので、
+    /// state 定義が皆無なら本診断は完全にスキップする。
+    fn workspace_has_any_state_definition(&self) -> bool {
+        self.index
+            .definitions
+            .get_all_definitions()
+            .iter()
+            .any(|s| s.kind == SymbolKind::UiRouterState)
     }
 
     /// 未使用スコープ変数をチェックし警告生成

--- a/src/index/definition_store.rs
+++ b/src/index/definition_store.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use dashmap::DashMap;
 use tower_lsp::lsp_types::Url;
 
-use crate::model::{Symbol, SymbolKind, SymbolReference};
+use crate::model::{JsStateNavigationReference, Symbol, SymbolKind, SymbolReference};
 
 /// シンボル定義・参照の管理ストア
 pub struct DefinitionStore {
@@ -13,6 +13,12 @@ pub struct DefinitionStore {
     /// `get_definitions_for_uri` 等の URI 逆引きを O(該当ドキュメントのシンボル数)
     /// で行うためのインデックス。重複登録を避けるため HashSet で保持する。
     document_symbols: DashMap<Url, HashSet<String>>,
+    /// JS 内の `$state.go('home')` / `$state.transitionTo('home')` の state 名参照。
+    /// URI 別に保持し、未登録 state 診断で「該当 JS ファイル内の警告位置」
+    /// を引くのに使う。通常の `references` (シンボル名キー) とは別に持たないと、
+    /// 「state 名に該当する SymbolReference」の中から JS 経路で来たものだけを
+    /// 効率良く取り出せない (HTML 経路の参照と混在するため)。
+    js_state_navigation_references: DashMap<Url, Vec<JsStateNavigationReference>>,
 }
 
 impl DefinitionStore {
@@ -21,6 +27,7 @@ impl DefinitionStore {
             definitions: DashMap::new(),
             references: DashMap::new(),
             document_symbols: DashMap::new(),
+            js_state_navigation_references: DashMap::new(),
         }
     }
 
@@ -295,6 +302,31 @@ impl DefinitionStore {
         result
     }
 
+    /// `$state.go('name')` / `$state.transitionTo('name')` の state 名参照を登録
+    pub fn add_js_state_navigation_reference(&self, reference: JsStateNavigationReference) {
+        let uri = reference.uri.clone();
+        let mut entry = self.js_state_navigation_references.entry(uri).or_default();
+        let is_duplicate = entry.iter().any(|r| {
+            r.span.start_line == reference.span.start_line
+                && r.span.start_col == reference.span.start_col
+                && r.state_name == reference.state_name
+        });
+        if !is_duplicate {
+            entry.push(reference);
+        }
+    }
+
+    /// 指定 URI の JS state 遷移参照 (`$state.go` / `$state.transitionTo`) を取得
+    pub fn get_js_state_navigation_references_for_uri(
+        &self,
+        uri: &Url,
+    ) -> Vec<JsStateNavigationReference> {
+        self.js_state_navigation_references
+            .get(uri)
+            .map(|v| v.value().clone())
+            .unwrap_or_default()
+    }
+
     pub fn clear_document(&self, uri: &Url) {
         if let Some((_, symbols)) = self.document_symbols.remove(uri) {
             for symbol_name in symbols {
@@ -319,12 +351,15 @@ impl DefinitionStore {
                 }
             }
         }
+        // JS state 遷移参照は URI キーなので一発で消せる
+        self.js_state_navigation_references.remove(uri);
     }
 
     pub fn clear_all(&self) {
         self.definitions.clear();
         self.references.clear();
         self.document_symbols.clear();
+        self.js_state_navigation_references.clear();
     }
 }
 

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -17,5 +17,5 @@ pub use html::{
 pub use inheritance::{NgIncludeBinding, NgViewBinding};
 pub use scope::{ControllerScope, HtmlControllerScope};
 pub use span::Span;
-pub use symbol::{Symbol, SymbolKind, SymbolReference};
+pub use symbol::{JsStateNavigationReference, Symbol, SymbolKind, SymbolReference};
 pub use template::{BindingSource, ComponentTemplateUrl, TemplateBinding};

--- a/src/model/symbol.rs
+++ b/src/model/symbol.rs
@@ -149,3 +149,32 @@ impl SymbolReference {
         self.span.end_col
     }
 }
+
+/// JS 内の `$state.go('home')` / `$state.transitionTo('home')` で参照される
+/// ui-router state 名と、その第1引数 (state 名リテラル) の位置範囲を表す。
+///
+/// `HtmlUiSrefReference` の JS 版。診断 (未登録 state 警告) の際に
+/// 「JS 内のどの位置に warning を出すべきか」を URI 別に逆引きするため、
+/// 通常の `SymbolReference` インデックス (シンボル名キー) とは別に
+/// URI キーで保持する。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsStateNavigationReference {
+    pub state_name: String,
+    pub uri: Url,
+    pub span: Span,
+}
+
+impl JsStateNavigationReference {
+    pub fn start_line(&self) -> u32 {
+        self.span.start_line
+    }
+    pub fn start_col(&self) -> u32 {
+        self.span.start_col
+    }
+    pub fn end_line(&self) -> u32 {
+        self.span.end_line
+    }
+    pub fn end_col(&self) -> u32 {
+        self.span.end_col
+    }
+}

--- a/tests/angularjs_common_syntax_test.rs
+++ b/tests/angularjs_common_syntax_test.rs
@@ -3973,3 +3973,149 @@ angular.module('app', []).controller('MyCtrl', ['$scope', function($scope) {
         labels
     );
 }
+
+// ====================================================================
+// PR (issue #61): 未登録 ui-router state 名の診断
+// ====================================================================
+
+#[test]
+fn test_diagnose_unknown_ui_sref_state_name_in_html() {
+    // ui-sref="users.detial" (typo) は state 定義 'users.detail' とマッチしないので
+    // 未登録 state 警告が出るべき。一方で正しい 'users.detail' には出ない。
+    use angularjs_lsp::config::DiagnosticsConfig;
+    use angularjs_lsp::handler::DiagnosticsHandler;
+    use std::sync::Arc;
+
+    let js = r#"
+angular.module('app', []).config(['$stateProvider', function($stateProvider) {
+    $stateProvider.state('users.detail', {
+        url: '/users/:id',
+        templateUrl: 'views/users/detail.html'
+    });
+}]);
+"#;
+    let html = r#"
+<div>
+    <a ui-sref="users.detail">OK</a>
+    <a ui-sref="users.detial">Typo</a>
+</div>
+"#;
+    let index = analyze_html(js, html);
+    let html_uri = Url::parse("file:///test.html").unwrap();
+
+    let diagnostics = DiagnosticsHandler::new(Arc::clone(&index), DiagnosticsConfig::default())
+        .diagnose_html(&html_uri);
+
+    let messages: Vec<&str> = diagnostics.iter().map(|d| d.message.as_str()).collect();
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("Unknown ui-router state 'users.detial'")),
+        "ui-sref='users.detial' (typo) に対し未登録 state 警告が出るべき (messages: {:?})",
+        messages
+    );
+    assert!(
+        !messages
+            .iter()
+            .any(|m| m.contains("Unknown ui-router state 'users.detail'")),
+        "正しい ui-sref='users.detail' に対し警告が出てはいけない (messages: {:?})",
+        messages
+    );
+}
+
+#[test]
+fn test_diagnose_unknown_state_go_in_js() {
+    // $state.go('users.detial') (typo) は警告。$state.go('home') は警告無し。
+    use angularjs_lsp::config::DiagnosticsConfig;
+    use angularjs_lsp::handler::DiagnosticsHandler;
+    use std::sync::Arc;
+
+    let js = r#"
+angular.module('app', [])
+.config(['$stateProvider', function($stateProvider) {
+    $stateProvider.state('home', { url: '/' });
+}])
+.controller('NavCtrl', ['$state', function($state) {
+    $state.go('home');
+    $state.go('users.detial');
+    $state.transitionTo('home');
+}]);
+"#;
+    let index = analyze_js(js);
+    let js_uri = Url::parse("file:///test.js").unwrap();
+
+    let diagnostics = DiagnosticsHandler::new(Arc::clone(&index), DiagnosticsConfig::default())
+        .diagnose_js(&js_uri);
+
+    let messages: Vec<&str> = diagnostics.iter().map(|d| d.message.as_str()).collect();
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("Unknown ui-router state 'users.detial'")),
+        "$state.go('users.detial') に対し未登録 state 警告が出るべき (messages: {:?})",
+        messages
+    );
+    assert!(
+        !messages
+            .iter()
+            .any(|m| m.contains("Unknown ui-router state 'home'")),
+        "登録済み state 'home' を参照する $state.go / transitionTo に警告が出てはいけない (messages: {:?})",
+        messages
+    );
+}
+
+#[test]
+fn test_diagnose_unknown_state_skipped_when_no_state_definitions() {
+    // workspace に state 定義が一つも無いプロジェクト (ui-router を使っていない or
+    // まだ解析されていない) では false positive を避けるため一切警告しない。
+    use angularjs_lsp::config::DiagnosticsConfig;
+    use angularjs_lsp::handler::DiagnosticsHandler;
+    use std::sync::Arc;
+
+    // state 定義は無し
+    let html = r#"<a ui-sref="some.state">Link</a>"#;
+    let index = analyze_html("", html);
+    let html_uri = Url::parse("file:///test.html").unwrap();
+
+    let diagnostics = DiagnosticsHandler::new(Arc::clone(&index), DiagnosticsConfig::default())
+        .diagnose_html(&html_uri);
+
+    let messages: Vec<&str> = diagnostics.iter().map(|d| d.message.as_str()).collect();
+    assert!(
+        !messages
+            .iter()
+            .any(|m| m.contains("Unknown ui-router state")),
+        "state 定義 0 件の workspace では false positive を避けるため警告しない (messages: {:?})",
+        messages
+    );
+}
+
+#[test]
+fn test_diagnose_unknown_state_severity_off_disables_check() {
+    // unknown_state_severity = "off" なら一切警告しない。
+    use angularjs_lsp::config::DiagnosticsConfig;
+    use angularjs_lsp::handler::DiagnosticsHandler;
+    use std::sync::Arc;
+
+    let js = r#"
+angular.module('app', []).config(['$stateProvider', function($stateProvider) {
+    $stateProvider.state('home', { url: '/' });
+}]);
+"#;
+    let html = r#"<a ui-sref="users.detial">Typo</a>"#;
+    let index = analyze_html(js, html);
+    let html_uri = Url::parse("file:///test.html").unwrap();
+
+    let mut config = DiagnosticsConfig::default();
+    config.unknown_state_severity = "off".to_string();
+    let diagnostics = DiagnosticsHandler::new(Arc::clone(&index), config).diagnose_html(&html_uri);
+
+    let messages: Vec<&str> = diagnostics.iter().map(|d| d.message.as_str()).collect();
+    assert!(
+        !messages
+            .iter()
+            .any(|m| m.contains("Unknown ui-router state")),
+        "unknown_state_severity='off' なら未登録 state 警告は出ないべき (messages: {:?})",
+        messages
+    );
+}


### PR DESCRIPTION
## Summary

- ui-sref / \$state.go / \$state.transitionTo で参照される ui-router state 名が、`$stateProvider.state(...)` 由来の定義と一致しない場合に diagnostic を発報する。
- \`ui-sref="users.detial"\` のような typo や、リネーム漏れによる存在しない state への遷移を編集時に検知できるようにする。

Closes #61

## 設計

- `DiagnosticsConfig` に `unknown_state_severity` (warning / error / hint / information / off) を追加。`off` で無効化可能。
- `JsStateNavigationReference` 型を新設し、`$state.go('name')` / `$state.transitionTo('name')` の第1引数位置を URI 別に `DefinitionStore` に保持する。HTML 経路 (`HtmlUiSrefReference`) と JS 経路を診断時に独立して引きたいため、通常の `SymbolReference` インデックス (シンボル名キー) とは別の URI キー専用インデックスを用意した。
- `diagnose_html` / `diagnose_js` から下記のチェックを呼ぶ:
  - HTML: `index.html.get_ui_sref_references_for_uri(uri)` をループし、各 `state_name` について `definitions.has_definition_of_kind(name, SymbolKind::UiRouterState)` で照合
  - JS: 上記の新規 URI 別 JS state nav reference をループし、同じく照合
- workspace に state 定義が 1 件もない (ui-router 未使用 / 解析未完了) 場合は false positive を避けるため両チェックを完全スキップ。
- 相対参照 (\`.\` / \`^.foo\`) は登録時点でスキップ済み (issue #46, #61 設計どおり)。

## 注意点 / 今後

- `ajsconfig.json` の `external_states` allowlist (lazy-loaded module の state など) は本 PR ではスコープ外。 `unknown_state_severity` のドキュメントコメントに TODO として残してある。
- 既存の `find-references` 用 `SymbolReference` 登録は従来どおり (HTML/JS 両方で `name = state_name` で `add_reference` する経路は変更なし)。

## Test plan

- [x] \`cargo build\` 警告ゼロ
- [x] \`cargo test\` 全件通過 (新規 4 件含む)
- [x] HTML 側で typo state 名に warning が出ることを統合テストで確認 (\`test_diagnose_unknown_ui_sref_state_name_in_html\`)
- [x] JS 側で typo state 名に warning が出ること、登録済み state には出ないことを統合テストで確認 (\`test_diagnose_unknown_state_go_in_js\`)
- [x] state 定義 0 件 workspace で false positive が出ないことを確認 (\`test_diagnose_unknown_state_skipped_when_no_state_definitions\`)
- [x] \`unknown_state_severity = "off"\` で診断が無効化されることを確認 (\`test_diagnose_unknown_state_severity_off_disables_check\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)