### PR TITLE
diagnostic: 存在しない directive / component を警告 (#62)

### DIFF
--- a/src/config/ajs_config.rs
+++ b/src/config/ajs_config.rs
@@ -40,6 +40,16 @@ pub struct DiagnosticsConfig {
     /// 未使用スコープ変数の警告を有効にする（デフォルト: true）
     #[serde(default = "default_true")]
     pub unused_scope_variables: bool,
+    /// 未登録 directive / component 参照の警告を有効にする（デフォルト: true）
+    #[serde(default = "default_true")]
+    pub unknown_directive_references: bool,
+    /// 未登録 directive / component の重要度
+    /// "error", "warning", "hint", "information"（デフォルト: "warning"）
+    ///
+    /// `severity` (汎用) と独立に設定したい場合に使う。指定しない場合は
+    /// `severity` と同じ値を使う（=後方互換）。
+    #[serde(default)]
+    pub unknown_directive_severity: Option<String>,
 }
 
 fn default_true() -> bool {
@@ -56,6 +66,8 @@ impl Default for DiagnosticsConfig {
             enabled: default_true(),
             severity: default_severity(),
             unused_scope_variables: default_true(),
+            unknown_directive_references: default_true(),
+            unknown_directive_severity: None,
         }
     }
 }
@@ -158,5 +170,23 @@ mod tests {
         assert!(config.enabled);
         assert_eq!(config.severity, "warning");
         assert!(config.unused_scope_variables);
+        assert!(config.unknown_directive_references);
+        assert!(config.unknown_directive_severity.is_none());
+    }
+
+    #[test]
+    fn test_diagnostics_unknown_directive_override() {
+        let json = r#"{
+            "diagnostics": {
+                "unknown_directive_references": false,
+                "unknown_directive_severity": "error"
+            }
+        }"#;
+        let config: AjsConfig = serde_json::from_str(json).unwrap();
+        assert!(!config.diagnostics.unknown_directive_references);
+        assert_eq!(
+            config.diagnostics.unknown_directive_severity.as_deref(),
+            Some("error")
+        );
     }
 }

--- a/src/handler/diagnostics.rs
+++ b/src/handler/diagnostics.rs
@@ -5,6 +5,7 @@ use tracing::debug;
 
 use crate::config::DiagnosticsConfig;
 use crate::index::Index;
+use crate::model::{DirectiveUsageType, SymbolKind};
 
 /// 診断ハンドラー
 pub struct DiagnosticsHandler {
@@ -19,13 +20,28 @@ impl DiagnosticsHandler {
 
     /// 重要度文字列をDiagnosticSeverityに変換
     fn parse_severity(&self) -> DiagnosticSeverity {
-        match self.config.severity.to_lowercase().as_str() {
+        Self::severity_from_str(&self.config.severity)
+    }
+
+    /// 任意の severity 文字列を DiagnosticSeverity に変換
+    fn severity_from_str(s: &str) -> DiagnosticSeverity {
+        match s.to_lowercase().as_str() {
             "error" => DiagnosticSeverity::ERROR,
             "warning" => DiagnosticSeverity::WARNING,
             "hint" => DiagnosticSeverity::HINT,
             "information" | "info" => DiagnosticSeverity::INFORMATION,
             _ => DiagnosticSeverity::WARNING,
         }
+    }
+
+    /// 未登録 directive / component 用の severity
+    /// `unknown_directive_severity` が指定されていればそれを、なければ `severity` を使う
+    fn parse_unknown_directive_severity(&self) -> DiagnosticSeverity {
+        self.config
+            .unknown_directive_severity
+            .as_deref()
+            .map(Self::severity_from_str)
+            .unwrap_or_else(|| self.parse_severity())
     }
 
     /// HTMLファイルの診断を実行
@@ -41,6 +57,11 @@ impl DiagnosticsHandler {
 
         // ローカル変数参照のチェック
         diagnostics.extend(self.check_local_variable_references(uri));
+
+        // 未登録 directive / component のチェック
+        if self.config.unknown_directive_references {
+            diagnostics.extend(self.check_unknown_directive_references(uri));
+        }
 
         diagnostics
     }
@@ -367,6 +388,70 @@ impl DiagnosticsHandler {
                     });
                 }
             }
+        }
+
+        diagnostics
+    }
+
+    /// 未登録 directive / component 参照のチェック
+    ///
+    /// HTML 内で要素 (`<my-cmp>`) や属性 (`<div my-directive>`) として使われている
+    /// カスタムディレクティブが workspace 内のどこにも `.directive(...)` /
+    /// `.component(...)` で登録されていない場合に警告を出す。
+    ///
+    /// false positive 抑制:
+    /// - 標準 HTML 属性 (class, id, ...) や標準 HTML 要素 (div, span, ...) は
+    ///   `directive_reference.rs` の登録時点で除外済み
+    /// - `ng-` プレフィックス組み込みディレクティブも登録時点で除外済み
+    /// - `data-` プレフィックスは正規化済み (登録側)
+    fn check_unknown_directive_references(&self, uri: &Url) -> Vec<Diagnostic> {
+        let mut diagnostics = Vec::new();
+        let severity = self.parse_unknown_directive_severity();
+
+        let references = self.index.html.get_all_directive_references_for_uri(uri);
+
+        for reference in references {
+            // workspace 内に Directive または Component の定義があるかチェック
+            let defs = self
+                .index
+                .definitions
+                .get_definitions(&reference.directive_name);
+            let registered = defs
+                .iter()
+                .any(|s| s.kind == SymbolKind::Directive || s.kind == SymbolKind::Component);
+
+            if registered {
+                continue;
+            }
+
+            let (kind_label, suggestion) = match reference.usage_type {
+                DirectiveUsageType::Element => ("component or directive", "component"),
+                DirectiveUsageType::Attribute => ("directive", "directive"),
+            };
+
+            diagnostics.push(Diagnostic {
+                range: Range {
+                    start: Position {
+                        line: reference.start_line,
+                        character: reference.start_col,
+                    },
+                    end: Position {
+                        line: reference.end_line,
+                        character: reference.end_col,
+                    },
+                },
+                severity: Some(severity),
+                code: None,
+                code_description: None,
+                source: Some("angularjs-lsp".to_string()),
+                message: format!(
+                    "Unknown {} '{}' is not registered with .{}(...) anywhere in the workspace",
+                    kind_label, reference.directive_name, suggestion
+                ),
+                related_information: None,
+                tags: None,
+                data: None,
+            });
         }
 
         diagnostics

--- a/tests/angularjs_common_syntax_test.rs
+++ b/tests/angularjs_common_syntax_test.rs
@@ -3973,3 +3973,165 @@ angular.module('app', []).controller('MyCtrl', ['$scope', function($scope) {
         labels
     );
 }
+
+// ====================================================================
+// Issue #62: 未登録 directive / component の使用を警告
+// ====================================================================
+
+#[test]
+fn test_diagnose_unknown_directive_element_warns() {
+    // workspace のどこにも .directive(...) / .component(...) で登録されていない
+    // カスタム要素 <my-cmpnt> (typo) は警告を出す。
+    use angularjs_lsp::config::DiagnosticsConfig;
+    use angularjs_lsp::handler::DiagnosticsHandler;
+
+    let js = r#"
+angular.module('app', []).component('myComponent', {
+    template: '<div>hello</div>'
+});
+"#;
+    // <my-cmpnt> は typo (登録名は myComponent / kebab: my-component)
+    let html = r#"<my-cmpnt></my-cmpnt>"#;
+    let index = analyze_html(js, html);
+    let html_uri = Url::parse("file:///test.html").unwrap();
+
+    let diagnostics = DiagnosticsHandler::new(Arc::clone(&index), DiagnosticsConfig::default())
+        .diagnose_html(&html_uri);
+
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.message.contains("'myCmpnt'")
+                && d.message.to_lowercase().contains("unknown")),
+        "未登録カスタム要素 <my-cmpnt> に対して警告が出るべき (diagnostics: {:?})",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_diagnose_unknown_directive_attribute_warns() {
+    // 属性として <div my-bind="..."> と書かれているが my-bind が登録されて
+    // いない場合は警告を出す。
+    use angularjs_lsp::config::DiagnosticsConfig;
+    use angularjs_lsp::handler::DiagnosticsHandler;
+
+    let js = r#"
+angular.module('app', []).controller('Ctrl', ['$scope', function($scope) {
+    $scope.value = 1;
+}]);
+"#;
+    let html = r#"<div ng-controller="Ctrl" my-bind="value"></div>"#;
+    let index = analyze_html(js, html);
+    let html_uri = Url::parse("file:///test.html").unwrap();
+
+    let diagnostics = DiagnosticsHandler::new(Arc::clone(&index), DiagnosticsConfig::default())
+        .diagnose_html(&html_uri);
+
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.message.contains("'myBind'")
+                && d.message.to_lowercase().contains("unknown")),
+        "未登録カスタム属性 my-bind に対して警告が出るべき (diagnostics: {:?})",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_diagnose_known_directive_does_not_warn() {
+    // 登録済みの directive / component に対しては警告を出さない。
+    use angularjs_lsp::config::DiagnosticsConfig;
+    use angularjs_lsp::handler::DiagnosticsHandler;
+
+    let js = r#"
+angular.module('app', [])
+    .component('myWidget', {
+        template: '<div></div>'
+    })
+    .directive('highlightMe', [function() {
+        return { restrict: 'A', link: function() {} };
+    }]);
+"#;
+    let html = r#"<my-widget highlight-me></my-widget>"#;
+    let index = analyze_html(js, html);
+    let html_uri = Url::parse("file:///test.html").unwrap();
+
+    let diagnostics = DiagnosticsHandler::new(Arc::clone(&index), DiagnosticsConfig::default())
+        .diagnose_html(&html_uri);
+
+    for d in &diagnostics {
+        assert!(
+            !d.message.contains("'myWidget'") || !d.message.to_lowercase().contains("unknown"),
+            "登録済み component <my-widget> に対して unknown 警告が出てはいけない (diagnostic: {})",
+            d.message
+        );
+        assert!(
+            !d.message.contains("'highlightMe'") || !d.message.to_lowercase().contains("unknown"),
+            "登録済み directive highlight-me に対して unknown 警告が出てはいけない (diagnostic: {})",
+            d.message
+        );
+    }
+}
+
+#[test]
+fn test_diagnose_standard_html_attributes_do_not_warn() {
+    // 標準 HTML 属性 (class, id, style, ...) や ng- 組み込みディレクティブ、
+    // aria-* / data-* などは directive_reference 登録時点で除外されているので
+    // 警告は一切出ないこと。
+    use angularjs_lsp::config::DiagnosticsConfig;
+    use angularjs_lsp::handler::DiagnosticsHandler;
+
+    let js = "";
+    let html = r#"
+<div id="root" class="container" style="color: red"
+     tabindex="0" aria-label="hello" data-id="42"
+     ng-if="true" ng-click="noop()">
+    <input type="text" placeholder="..." readonly />
+</div>
+"#;
+    let index = analyze_html(js, html);
+    let html_uri = Url::parse("file:///test.html").unwrap();
+
+    let diagnostics = DiagnosticsHandler::new(Arc::clone(&index), DiagnosticsConfig::default())
+        .diagnose_html(&html_uri);
+
+    let unknown_msgs: Vec<&str> = diagnostics
+        .iter()
+        .filter(|d| d.message.to_lowercase().contains("unknown"))
+        .map(|d| d.message.as_str())
+        .collect();
+    assert!(
+        unknown_msgs.is_empty(),
+        "標準 HTML 属性 / ng-* / aria-* / data-* に対して unknown 警告が出てはいけない (msgs: {:?})",
+        unknown_msgs
+    );
+}
+
+#[test]
+fn test_diagnose_unknown_directive_disabled_by_config() {
+    // unknown_directive_references = false で機能を無効化できる。
+    use angularjs_lsp::config::DiagnosticsConfig;
+    use angularjs_lsp::handler::DiagnosticsHandler;
+
+    let js = "";
+    let html = r#"<my-undefined-component></my-undefined-component>"#;
+    let index = analyze_html(js, html);
+    let html_uri = Url::parse("file:///test.html").unwrap();
+
+    let mut config = DiagnosticsConfig::default();
+    config.unknown_directive_references = false;
+
+    let diagnostics =
+        DiagnosticsHandler::new(Arc::clone(&index), config).diagnose_html(&html_uri);
+
+    let unknown_msgs: Vec<&str> = diagnostics
+        .iter()
+        .filter(|d| d.message.to_lowercase().contains("unknown"))
+        .map(|d| d.message.as_str())
+        .collect();
+    assert!(
+        unknown_msgs.is_empty(),
+        "unknown_directive_references=false の場合は unknown 警告が出てはいけない (msgs: {:?})",
+        unknown_msgs
+    );
+}


### PR DESCRIPTION
## Summary
- HTML 内で使われているカスタム directive / component が workspace のどこにも `.directive(...)` / `.component(...)` で登録されていない場合に警告を出す診断を追加 (`DiagnosticsHandler::check_unknown_directive_references`)。
- typo (`<my-cmpnt>`) やリネーム時の取りこぼし、未定義属性 (`<div my-bind="...">`) を早期に発見できる。
- false positive 抑制は登録段階 (`directive_reference.rs`) に既に集約されているため、診断側で重複フィルタは付けず一貫性を保った (標準 HTML 属性 / 要素・`ng-*` ビルトイン・`aria-*` / `data-*` は登録対象外)。
- `DiagnosticsConfig` に `unknown_directive_references` (bool, デフォルト true) と `unknown_directive_severity` (Option<String>) を追加。`unknown_directive_severity` は既存の `severity` と独立して severity を設定したい場合に使う。

## Test plan
- [x] `cargo build` 警告ゼロ
- [x] `cargo test` 全通過 (148 → 153 件、新規 5 件)
- [x] `test_diagnose_unknown_directive_element_warns`: typo した `<my-cmpnt>` で警告
- [x] `test_diagnose_unknown_directive_attribute_warns`: 未登録の `my-bind` 属性で警告
- [x] `test_diagnose_known_directive_does_not_warn`: 登録済み directive / component に警告無し
- [x] `test_diagnose_standard_html_attributes_do_not_warn`: 標準 HTML 属性 / `ng-*` / `aria-*` / `data-*` で false positive 無し
- [x] `test_diagnose_unknown_directive_disabled_by_config`: `unknown_directive_references=false` で機能無効化

Closes #62

Generated with Claude Code