### PR TITLE
feat: code action — 未定義 $scope property を controller に追加 (#69)

### DIFF
--- a/src/handler/code_action.rs
+++ b/src/handler/code_action.rs
@@ -1,0 +1,343 @@
+//! Code action ハンドラ。
+//!
+//! 現状サポート:
+//! - **未定義 \$scope プロパティのクイックフィックス** (Issue #69)
+//!   `{{ vm.foo }}` の `foo` が controller に未定義というケースで、controller 関数
+//!   本体の先頭に `this.foo = null;` (controller as) または `$scope.foo = null;`
+//!   を挿入する CodeAction を提示する。
+//!
+//! `diagnostics.rs` 側で警告に
+//! [`UNDEFINED_SCOPE_PROPERTY_CODE`](super::diagnostics::UNDEFINED_SCOPE_PROPERTY_CODE)
+//! を `code` フィールドにセットしてあり、本ハンドラはそれをキーに該当診断を識別する。
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tower_lsp::lsp_types::{
+    CodeAction, CodeActionKind, CodeActionOrCommand, CodeActionParams, CodeActionResponse,
+    NumberOrString, Position, Range, TextEdit, Url, WorkspaceEdit,
+};
+
+use crate::handler::diagnostics::UNDEFINED_SCOPE_PROPERTY_CODE;
+use crate::index::Index;
+use crate::model::ControllerScope;
+use crate::util::is_html_file;
+
+/// Code action ハンドラ。
+pub struct CodeActionHandler {
+    index: Arc<Index>,
+}
+
+impl CodeActionHandler {
+    pub fn new(index: Arc<Index>) -> Self {
+        Self { index }
+    }
+
+    /// `textDocument/codeAction` のメインエントリ。
+    ///
+    /// `sources` は controller 側 JS の最新ソース (open buffer から得られる場合) を
+    /// 渡すと、インデント推定に使われる。`None` でも動作する (デフォルト 4 spaces)。
+    pub fn code_action(
+        &self,
+        params: CodeActionParams,
+        sources: &HashMap<Url, String>,
+    ) -> Option<CodeActionResponse> {
+        let html_uri = params.text_document.uri.clone();
+        if !is_html_file(&html_uri) {
+            return None;
+        }
+
+        let mut actions: Vec<CodeActionOrCommand> = Vec::new();
+
+        for diagnostic in &params.context.diagnostics {
+            // 自分が出した未定義 \$scope プロパティ診断のみを処理する
+            if !is_undefined_scope_property_diagnostic(diagnostic) {
+                continue;
+            }
+            // params.range と diagnostic 範囲が重なっていない場合はスキップ
+            if !ranges_overlap(&params.range, &diagnostic.range) {
+                continue;
+            }
+
+            actions.extend(self.actions_for_diagnostic(&html_uri, diagnostic, sources));
+        }
+
+        if actions.is_empty() {
+            None
+        } else {
+            Some(actions)
+        }
+    }
+
+    /// 単一の診断に対応する CodeAction 群を生成する。
+    fn actions_for_diagnostic(
+        &self,
+        html_uri: &Url,
+        diagnostic: &tower_lsp::lsp_types::Diagnostic,
+        sources: &HashMap<Url, String>,
+    ) -> Vec<CodeActionOrCommand> {
+        let mut actions: Vec<CodeActionOrCommand> = Vec::new();
+
+        let line = diagnostic.range.start.line;
+        let col = diagnostic.range.start.character;
+
+        // 該当位置の HTML scope reference を引く
+        let html_ref = match self
+            .index
+            .html
+            .find_html_scope_reference_at(html_uri, line, col)
+        {
+            Some(r) => r,
+            None => return actions,
+        };
+
+        // property_path を "alias" と "property" に分解する
+        // 例: "vm.foo" -> ("vm", "foo"); "foo" -> (None, "foo")
+        let (alias, property) = split_alias_and_property(&html_ref.property_path);
+
+        // 解決すべき controller を決定
+        // - alias がある場合: alias.resolve_controller_by_alias で 1 つに決まる
+        // - alias がない場合: resolve_controllers_for_html で複数候補を取得
+        let controller_candidates: Vec<(String, bool)> = if let Some(alias_name) = alias.as_deref()
+        {
+            if let Some(controller) =
+                self.index
+                    .resolve_controller_by_alias(html_uri, line, alias_name)
+            {
+                // alias がある = controller as 構文 → this.foo を優先
+                vec![(controller, true)]
+            } else {
+                Vec::new()
+            }
+        } else {
+            // alias がない = $scope.foo 形式
+            self.index
+                .resolve_controllers_for_html(html_uri, line)
+                .into_iter()
+                .map(|name| (name, false))
+                .collect()
+        };
+
+        for (controller_name, prefer_this) in controller_candidates {
+            // controller の JS 定義 (ControllerScope) を取得
+            let scopes = self
+                .index
+                .controllers
+                .get_controller_scopes_by_name(&controller_name);
+
+            for scope in scopes {
+                if let Some(action) = build_insert_property_action(
+                    &controller_name,
+                    &property,
+                    prefer_this,
+                    &scope,
+                    diagnostic,
+                    sources,
+                ) {
+                    actions.push(CodeActionOrCommand::CodeAction(action));
+                }
+            }
+        }
+
+        actions
+    }
+}
+
+/// Diagnostic に [`UNDEFINED_SCOPE_PROPERTY_CODE`] が付与されているか判定する。
+fn is_undefined_scope_property_diagnostic(diagnostic: &tower_lsp::lsp_types::Diagnostic) -> bool {
+    matches!(
+        &diagnostic.code,
+        Some(NumberOrString::String(s)) if s == UNDEFINED_SCOPE_PROPERTY_CODE
+    )
+}
+
+/// 2 つの Range が重なっているかを判定する。
+/// `start1 <= end2 && start2 <= end1` の形式 (両端含む)。
+fn ranges_overlap(a: &Range, b: &Range) -> bool {
+    !position_lt(&b.end, &a.start) && !position_lt(&a.end, &b.start)
+}
+
+fn position_lt(a: &Position, b: &Position) -> bool {
+    if a.line != b.line {
+        a.line < b.line
+    } else {
+        a.character < b.character
+    }
+}
+
+/// "alias.property" / "property" を分解する。
+/// 例:
+/// - `"vm.foo"` → `(Some("vm"), "foo")`
+/// - `"vm.user.name"` → `(Some("vm"), "user.name")` (depth が深い場合は最深部まで保持)
+/// - `"foo"` → `(None, "foo")`
+fn split_alias_and_property(property_path: &str) -> (Option<String>, String) {
+    if let Some(idx) = property_path.find('.') {
+        let alias = property_path[..idx].to_string();
+        let prop = property_path[idx + 1..].to_string();
+        (Some(alias), prop)
+    } else {
+        (None, property_path.to_string())
+    }
+}
+
+/// 「property tail」 を抽出する。
+/// 挿入するのは scope 直下の最初の segment のみ (例: `"user.name"` → `"user"`)。
+fn property_root_segment(property: &str) -> &str {
+    match property.find('.') {
+        Some(idx) => &property[..idx],
+        None => property,
+    }
+}
+
+/// controller 内に `this.X = null;` または `$scope.X = null;` を挿入する CodeAction を構築する。
+fn build_insert_property_action(
+    controller_name: &str,
+    property: &str,
+    prefer_this: bool,
+    scope: &ControllerScope,
+    diagnostic: &tower_lsp::lsp_types::Diagnostic,
+    sources: &HashMap<Url, String>,
+) -> Option<CodeAction> {
+    // ネストした property の場合は root segment のみを挿入
+    // 例: `vm.user.name` → `this.user = null;` (深い構造の作成は手動)
+    let prop_to_insert = property_root_segment(property);
+    if prop_to_insert.is_empty() {
+        return None;
+    }
+
+    // 挿入位置: function body の **冒頭** (= body_start_line の **次の行**先頭)
+    // 既存の最初の statement の前に新しい行を差し込む形になる。
+    let insert_line = scope.start_line.saturating_add(1);
+
+    // インデント推定: 利用可能なら body 先頭行の leading whitespace を流用、
+    // ダメなら 4 spaces をデフォルトにする。
+    let indent =
+        detect_indent_from_source(sources.get(&scope.uri), insert_line).unwrap_or_else(|| {
+            "    ".to_string()
+        });
+
+    let prefix = if prefer_this { "this" } else { "$scope" };
+    let new_text = format!("{}{}.{} = null;\n", indent, prefix, prop_to_insert);
+
+    let title = format!(
+        "Add `{}.{} = null;` to controller `{}`",
+        prefix, prop_to_insert, controller_name
+    );
+
+    let edit = TextEdit {
+        range: Range {
+            start: Position {
+                line: insert_line,
+                character: 0,
+            },
+            end: Position {
+                line: insert_line,
+                character: 0,
+            },
+        },
+        new_text,
+    };
+
+    let mut changes: HashMap<Url, Vec<TextEdit>> = HashMap::new();
+    changes.insert(scope.uri.clone(), vec![edit]);
+
+    Some(CodeAction {
+        title,
+        kind: Some(CodeActionKind::QUICKFIX),
+        diagnostics: Some(vec![diagnostic.clone()]),
+        edit: Some(WorkspaceEdit {
+            changes: Some(changes),
+            ..Default::default()
+        }),
+        command: None,
+        is_preferred: Some(true),
+        disabled: None,
+        data: None,
+    })
+}
+
+/// 指定行のソースから leading whitespace を抽出してインデント文字列として返す。
+/// `source` が `None`、行が存在しない、または空行で leading whitespace を含まない
+/// 場合は `None` を返す。
+fn detect_indent_from_source(source: Option<&String>, line: u32) -> Option<String> {
+    let src = source?;
+    let target = src.lines().nth(line as usize)?;
+    let indent: String = target
+        .chars()
+        .take_while(|c| *c == ' ' || *c == '\t')
+        .collect();
+    if indent.is_empty() {
+        None
+    } else {
+        Some(indent)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_alias_and_property_handles_dot() {
+        assert_eq!(
+            split_alias_and_property("vm.foo"),
+            (Some("vm".to_string()), "foo".to_string())
+        );
+        assert_eq!(
+            split_alias_and_property("vm.user.name"),
+            (Some("vm".to_string()), "user.name".to_string())
+        );
+        assert_eq!(
+            split_alias_and_property("foo"),
+            (None, "foo".to_string())
+        );
+    }
+
+    #[test]
+    fn property_root_segment_returns_first_segment() {
+        assert_eq!(property_root_segment("foo"), "foo");
+        assert_eq!(property_root_segment("user.name"), "user");
+        assert_eq!(property_root_segment("a.b.c"), "a");
+    }
+
+    #[test]
+    fn ranges_overlap_works() {
+        let r = |sl, sc, el, ec| Range {
+            start: Position {
+                line: sl,
+                character: sc,
+            },
+            end: Position {
+                line: el,
+                character: ec,
+            },
+        };
+        // 完全一致
+        assert!(ranges_overlap(&r(1, 0, 1, 5), &r(1, 0, 1, 5)));
+        // 重なる
+        assert!(ranges_overlap(&r(1, 0, 1, 10), &r(1, 5, 1, 15)));
+        // a が b の前
+        assert!(!ranges_overlap(&r(1, 0, 1, 5), &r(1, 6, 1, 10)));
+        // a が b の後
+        assert!(!ranges_overlap(&r(1, 10, 1, 15), &r(1, 0, 1, 5)));
+        // 行違い
+        assert!(!ranges_overlap(&r(1, 0, 1, 5), &r(2, 0, 2, 5)));
+    }
+
+    #[test]
+    fn detect_indent_from_source_extracts_leading_whitespace() {
+        let src = "function f() {\n    var a = 1;\n\tvar b = 2;\nno_indent;\n".to_string();
+        assert_eq!(
+            detect_indent_from_source(Some(&src), 1),
+            Some("    ".to_string())
+        );
+        assert_eq!(
+            detect_indent_from_source(Some(&src), 2),
+            Some("\t".to_string())
+        );
+        assert_eq!(detect_indent_from_source(Some(&src), 3), None);
+        // 範囲外
+        assert_eq!(detect_indent_from_source(Some(&src), 100), None);
+        assert_eq!(detect_indent_from_source(None, 1), None);
+    }
+}

--- a/src/handler/diagnostics.rs
+++ b/src/handler/diagnostics.rs
@@ -1,10 +1,16 @@
 use std::sync::Arc;
 
-use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, DiagnosticTag, Position, Range, Url};
+use tower_lsp::lsp_types::{
+    Diagnostic, DiagnosticSeverity, DiagnosticTag, NumberOrString, Position, Range, Url,
+};
 use tracing::debug;
 
 use crate::config::DiagnosticsConfig;
 use crate::index::Index;
+
+/// 未定義 \$scope プロパティ診断に付与する code。
+/// `code_action` ハンドラはこれをキーに該当診断を識別する。
+pub const UNDEFINED_SCOPE_PROPERTY_CODE: &str = "angularjs-lsp.undefined-scope-property";
 
 /// 診断ハンドラー
 pub struct DiagnosticsHandler {
@@ -265,7 +271,9 @@ impl DiagnosticsHandler {
                             },
                         },
                         severity: Some(severity),
-                        code: None,
+                        code: Some(NumberOrString::String(
+                            UNDEFINED_SCOPE_PROPERTY_CODE.to_string(),
+                        )),
                         code_description: None,
                         source: Some("angularjs-lsp".to_string()),
                         message: format!(
@@ -354,7 +362,9 @@ impl DiagnosticsHandler {
                             },
                         },
                         severity: Some(severity),
-                        code: None,
+                        code: Some(NumberOrString::String(
+                            UNDEFINED_SCOPE_PROPERTY_CODE.to_string(),
+                        )),
                         code_description: None,
                         source: Some("angularjs-lsp".to_string()),
                         message: format!(

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -1,7 +1,8 @@
+mod code_action;
 mod codelens;
 mod completion;
 mod definition;
-mod diagnostics;
+pub mod diagnostics;
 mod document_symbol;
 mod hover;
 mod references;
@@ -11,6 +12,7 @@ mod semantic_tokens;
 mod signature_help;
 mod workspace_symbol;
 
+pub use code_action::CodeActionHandler;
 pub use codelens::CodeLensHandler;
 pub use completion::CompletionHandler;
 pub use definition::DefinitionHandler;

--- a/src/index/controller_store.rs
+++ b/src/index/controller_store.rs
@@ -58,6 +58,22 @@ impl ControllerStore {
             .collect()
     }
 
+    /// コントローラー名から ControllerScope を取得する。
+    ///
+    /// 同名 controller が複数 (例: 別ファイルで再定義) ある場合は全て返す。
+    /// code action で controller body 先頭にコードを挿入する用途で使う。
+    pub fn get_controller_scopes_by_name(&self, name: &str) -> Vec<ControllerScope> {
+        let mut result = Vec::new();
+        for entry in self.controller_scopes.iter() {
+            for scope in entry.value() {
+                if scope.name == name {
+                    result.push(scope.clone());
+                }
+            }
+        }
+        result
+    }
+
     // ========== HTML Controller Scopes ==========
 
     pub fn add_html_controller_scope(&self, scope: HtmlControllerScope) {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -20,9 +20,9 @@ use crate::analyzer::js::AngularJsAnalyzer;
 use crate::cache::{CacheLoader, CacheWriter};
 use crate::config::{AjsConfig, DiagnosticsConfig, PathMatcher};
 use crate::handler::{
-    CodeLensHandler, CompletionHandler, DefinitionHandler, DiagnosticsHandler,
-    DocumentSymbolHandler, HoverHandler, ReferencesHandler, RenameHandler,
-    SemanticTokensHandler, SignatureHelpHandler, WorkspaceSymbolHandler,
+    CodeActionHandler, CodeLensHandler, CompletionHandler, DefinitionHandler,
+    DiagnosticsHandler, DocumentSymbolHandler, HoverHandler, ReferencesHandler,
+    RenameHandler, SemanticTokensHandler, SignatureHelpHandler, WorkspaceSymbolHandler,
 };
 use crate::index::Index;
 use crate::ts_proxy::TsProxy;
@@ -1349,6 +1349,13 @@ impl LanguageServer for Backend {
                     commands: vec!["angularjs-lsp.refreshIndex".to_string()],
                     work_done_progress_options: Default::default(),
                 }),
+                code_action_provider: Some(CodeActionProviderCapability::Options(
+                    CodeActionOptions {
+                        code_action_kinds: Some(vec![CodeActionKind::QUICKFIX]),
+                        work_done_progress_options: Default::default(),
+                        resolve_provider: Some(false),
+                    },
+                )),
                 ..Default::default()
             },
         })
@@ -2058,6 +2065,28 @@ impl LanguageServer for Backend {
         let index = Arc::clone(&self.index);
         let result = tokio::task::spawn_blocking(move || {
             RenameHandler::new(index).prepare_rename(params)
+        })
+        .await
+        .ok()
+        .flatten();
+        Ok(result)
+    }
+
+    async fn code_action(
+        &self,
+        params: CodeActionParams,
+    ) -> Result<Option<CodeActionResponse>> {
+        let index = Arc::clone(&self.index);
+        // controller 側 JS の最新ソース (open buffer) を渡してインデント推定に使う。
+        // 簡単のため全 open document を投入する (open 数は大抵そう多くない)。
+        let sources: HashMap<Url, String> = self
+            .documents
+            .iter()
+            .map(|entry| (entry.key().clone(), entry.value().clone()))
+            .collect();
+
+        let result = tokio::task::spawn_blocking(move || {
+            CodeActionHandler::new(index).code_action(params, &sources)
         })
         .await
         .ok()

--- a/tests/code_action_test.rs
+++ b/tests/code_action_test.rs
@@ -1,0 +1,287 @@
+//! Issue #69: 未定義 \$scope プロパティ → controller に追加するクイックフィックス
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tower_lsp::lsp_types::{
+    CodeActionContext, CodeActionOrCommand, CodeActionParams, PartialResultParams, Position,
+    Range, TextDocumentIdentifier, Url, WorkDoneProgressParams,
+};
+
+use angularjs_lsp::analyzer::html::HtmlAngularJsAnalyzer;
+use angularjs_lsp::analyzer::js::AngularJsAnalyzer;
+use angularjs_lsp::config::DiagnosticsConfig;
+use angularjs_lsp::handler::{CodeActionHandler, DiagnosticsHandler};
+use angularjs_lsp::index::Index;
+
+/// JS と HTML を解析して Index を返すヘルパー (テスト用 URL 固定)。
+fn analyze(
+    js_source: &str,
+    html_source: &str,
+) -> (Arc<Index>, Url, Url) {
+    let index = Arc::new(Index::new());
+    let js_analyzer = Arc::new(AngularJsAnalyzer::new(index.clone()));
+    let html_analyzer = HtmlAngularJsAnalyzer::new(index.clone(), js_analyzer.clone());
+
+    let js_uri = Url::parse("file:///test.js").unwrap();
+    js_analyzer.analyze_document(&js_uri, js_source);
+
+    let html_uri = Url::parse("file:///test.html").unwrap();
+    html_analyzer.analyze_document(&html_uri, html_source);
+
+    (index, js_uri, html_uri)
+}
+
+/// 指定 URI に対して診断 → code action を求めるヘルパー。
+/// `range_at_first_diag` が true の場合は params.range を最初の診断範囲に合わせる。
+fn run_code_action(
+    index: &Arc<Index>,
+    html_uri: &Url,
+    js_uri: &Url,
+    js_source: &str,
+) -> Vec<CodeActionOrCommand> {
+    let diagnostics = DiagnosticsHandler::new(Arc::clone(index), DiagnosticsConfig::default())
+        .diagnose_html(html_uri);
+
+    // 最初の診断範囲を range として使う
+    let range = diagnostics
+        .first()
+        .map(|d| d.range)
+        .unwrap_or(Range {
+            start: Position {
+                line: 0,
+                character: 0,
+            },
+            end: Position {
+                line: 0,
+                character: 0,
+            },
+        });
+
+    let params = CodeActionParams {
+        text_document: TextDocumentIdentifier {
+            uri: html_uri.clone(),
+        },
+        range,
+        context: CodeActionContext {
+            diagnostics,
+            only: None,
+            trigger_kind: None,
+        },
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+    };
+
+    let mut sources = HashMap::new();
+    sources.insert(js_uri.clone(), js_source.to_string());
+
+    CodeActionHandler::new(Arc::clone(index))
+        .code_action(params, &sources)
+        .unwrap_or_default()
+}
+
+/// `controller as vm` 構文で未定義 `vm.foo` 参照に対し `this.foo = null;` を
+/// 挿入する code action が生成される。
+#[test]
+fn test_code_action_inserts_this_property_for_controller_as() {
+    let js = r#"
+angular.module('app', []).controller('MainCtrl', ['$scope', function($scope) {
+    $scope.bar = 1;
+}]);
+"#;
+    let html = r#"
+<div ng-controller="MainCtrl as vm">
+    {{ vm.foo }}
+</div>
+"#;
+    let (index, js_uri, html_uri) = analyze(js, html);
+
+    let actions = run_code_action(&index, &html_uri, &js_uri, js);
+
+    // 少なくとも 1 件は出るはず
+    assert!(
+        !actions.is_empty(),
+        "未定義 vm.foo に対して code action が出るべき (actions: {:?})",
+        actions
+    );
+
+    // controller as → this.foo を優先
+    let titles: Vec<String> = actions
+        .iter()
+        .filter_map(|a| match a {
+            CodeActionOrCommand::CodeAction(ca) => Some(ca.title.clone()),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        titles.iter().any(|t| t.contains("this.foo")),
+        "controller as の場合は 'this.foo' を提案するべき (titles: {:?})",
+        titles
+    );
+    assert!(
+        titles.iter().any(|t| t.contains("MainCtrl")),
+        "controller 名 'MainCtrl' が title に含まれるべき (titles: {:?})",
+        titles
+    );
+
+    // edit が controller の JS body に対するものになっていること
+    let action = actions
+        .iter()
+        .find_map(|a| match a {
+            CodeActionOrCommand::CodeAction(ca) if ca.title.contains("this.foo") => Some(ca),
+            _ => None,
+        })
+        .expect("this.foo を含む action が必要");
+    let edit = action.edit.as_ref().expect("WorkspaceEdit が必要");
+    let changes = edit.changes.as_ref().expect("changes が必要");
+    let edits = changes
+        .get(&js_uri)
+        .expect("controller JS の URI に対する TextEdit があるべき");
+    assert_eq!(edits.len(), 1, "1 件の挿入");
+    let new_text = &edits[0].new_text;
+    assert!(
+        new_text.contains("this.foo = null;"),
+        "挿入テキストに 'this.foo = null;' が含まれるべき (text: {:?})",
+        new_text
+    );
+}
+
+/// `$scope.foo` 形式 (alias なし、`{{ foo }}`) の未定義参照では
+/// `$scope.foo = null;` 挿入の code action が出る。
+#[test]
+fn test_code_action_inserts_scope_property_for_dollar_scope_form() {
+    let js = r#"
+angular.module('app', []).controller('UserCtrl', ['$scope', function($scope) {
+    $scope.bar = 1;
+}]);
+"#;
+    let html = r#"
+<div ng-controller="UserCtrl">
+    {{ foo }}
+</div>
+"#;
+    let (index, js_uri, html_uri) = analyze(js, html);
+
+    let actions = run_code_action(&index, &html_uri, &js_uri, js);
+    assert!(
+        !actions.is_empty(),
+        "未定義 foo に対して code action が出るべき"
+    );
+
+    let titles: Vec<String> = actions
+        .iter()
+        .filter_map(|a| match a {
+            CodeActionOrCommand::CodeAction(ca) => Some(ca.title.clone()),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        titles.iter().any(|t| t.contains("$scope.foo")),
+        "alias なし参照では '$scope.foo' を提案するべき (titles: {:?})",
+        titles
+    );
+
+    // 挿入テキストの確認
+    let action = actions
+        .iter()
+        .find_map(|a| match a {
+            CodeActionOrCommand::CodeAction(ca) if ca.title.contains("$scope.foo") => Some(ca),
+            _ => None,
+        })
+        .expect("$scope.foo を含む action が必要");
+    let edit = action.edit.as_ref().expect("WorkspaceEdit が必要");
+    let changes = edit.changes.as_ref().expect("changes が必要");
+    let edits = changes
+        .get(&js_uri)
+        .expect("controller JS の URI に対する TextEdit があるべき");
+    let new_text = &edits[0].new_text;
+    assert!(
+        new_text.contains("$scope.foo = null;"),
+        "挿入テキストに '$scope.foo = null;' が含まれるべき (text: {:?})",
+        new_text
+    );
+}
+
+/// 候補となる ControllerScope (= `$scope` 注入された JS controller) が無い場合、
+/// code action は提示されない。
+#[test]
+fn test_code_action_returns_none_when_no_controller_scope() {
+    // controller 自体は定義されているが $scope 注入が無いため ControllerScope は登録されない
+    let js = r#"
+angular.module('app', []).controller('NoScopeCtrl', function() {
+    this.bar = 1;
+});
+"#;
+    let html = r#"
+<div ng-controller="NoScopeCtrl as vm">
+    {{ vm.foo }}
+</div>
+"#;
+    let (index, js_uri, html_uri) = analyze(js, html);
+
+    let actions = run_code_action(&index, &html_uri, &js_uri, js);
+    // ControllerScope (＝ \$scope DI) が無い → 挿入位置が決まらない → code action 0 件
+    assert!(
+        actions.is_empty(),
+        "ControllerScope が無い場合は code action を出さない (actions: {:?})",
+        actions
+    );
+}
+
+/// 別の診断範囲 (request の range と重ならない) には code action を出さない。
+#[test]
+fn test_code_action_filters_by_range() {
+    let js = r#"
+angular.module('app', []).controller('MainCtrl', ['$scope', function($scope) {
+    $scope.bar = 1;
+}]);
+"#;
+    let html = r#"
+<div ng-controller="MainCtrl as vm">
+    {{ vm.foo }}
+</div>
+"#;
+    let (index, js_uri, html_uri) = analyze(js, html);
+
+    let diagnostics = DiagnosticsHandler::new(Arc::clone(&index), DiagnosticsConfig::default())
+        .diagnose_html(&html_uri);
+    assert!(
+        !diagnostics.is_empty(),
+        "前提として未定義診断が出ること"
+    );
+
+    // 診断範囲とは関係ない別の場所を range として渡す
+    let unrelated_range = Range {
+        start: Position {
+            line: 100,
+            character: 0,
+        },
+        end: Position {
+            line: 100,
+            character: 1,
+        },
+    };
+
+    let params = CodeActionParams {
+        text_document: TextDocumentIdentifier {
+            uri: html_uri.clone(),
+        },
+        range: unrelated_range,
+        context: CodeActionContext {
+            diagnostics,
+            only: None,
+            trigger_kind: None,
+        },
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+    };
+
+    let mut sources = HashMap::new();
+    sources.insert(js_uri.clone(), js.to_string());
+
+    let result = CodeActionHandler::new(Arc::clone(&index)).code_action(params, &sources);
+    assert!(
+        result.is_none() || result.unwrap().is_empty(),
+        "params.range と重ならない診断には code action を出さない"
+    );
+}


### PR DESCRIPTION
## Summary
- `textDocument/codeAction` を実装し、未定義 \$scope プロパティ診断 (例: `{{ vm.foo }}` の `foo` が controller 未定義) に対するクイックフィックスを提供
- controller as の場合は `this.foo = null;`、それ以外は `$scope.foo = null;` を controller 関数本体の冒頭に挿入
- 複数 controller 候補がある場合は controller ごとに別 action として提示。range フィルタで `params.range` と重なる診断のみを処理

## 変更点
- `DiagnosticsHandler::check_scope_references` の未定義警告に `code: "angularjs-lsp.undefined-scope-property"` を付与し、code_action から識別可能にする
- 新規 `src/handler/code_action.rs` (`CodeActionHandler`) — diagnostic を起点に HtmlScopeReference → alias 解決 → ControllerScope 引き → WorkspaceEdit を構築
- `ControllerStore::get_controller_scopes_by_name` ヘルパーを追加 (controller 名→body 行範囲)
- `server/mod.rs` で `code_action_provider` capability を宣言し、`async fn code_action` を実装。open buffer 全件をインデント推定用に handler へ渡す

## Test plan
- [x] `cargo build` 警告ゼロ (既存の preexisting `has_any_definition` warning を除く)
- [x] `cargo test` 全通過 (330 test 中 ok、新規 4 件含む)
- [x] 統合テスト 4 件 (`tests/code_action_test.rs`):
    - `controller as vm` で `this.foo = null;` 挿入
    - alias なし `{{ foo }}` で `$scope.foo = null;` 挿入
    - controller の \$scope DI が無く ControllerScope が登録されていない場合は code action 0 件
    - `params.range` が診断と重ならない場合は code action 0 件

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)