### PR TITLE
diagnostic: DI 配列の未登録サービス名を警告 (typo 候補付き) (#63)

### DIFF
--- a/src/analyzer/js/di.rs
+++ b/src/analyzer/js/di.rs
@@ -5,6 +5,7 @@ use tree_sitter::Node;
 
 use super::context::{AnalyzerContext, DiInfo};
 use super::AngularJsAnalyzer;
+use crate::index::DiUsage;
 use crate::model::{ControllerScope, SymbolReference};
 
 impl AngularJsAnalyzer {
@@ -124,18 +125,30 @@ impl AngularJsAnalyzer {
 
     /// `$inject` 配列から依存サービスを抽出する
     ///
-    /// `$` で始まるAngular組み込みサービスはスキップ
+    /// `$` で始まるAngular組み込みサービスはスキップ (参照登録のみ)。
+    /// 一方で「未知サービス警告 (#63)」用に `$` 付きも含めて DI usage を記録する。
     pub(super) fn extract_inject_dependencies(&self, node: Node, source: &str, uri: &Url) {
         if node.kind() == "array" {
             let mut cursor = node.walk();
             for child in node.children(&mut cursor) {
                 if child.kind() == "string" {
                     let dep_name = self.extract_string_value(child, source);
+                    let span = self.span_of(child);
+
+                    // 未知サービス警告用: $ 付きも含めて全 DI 文字列を記録
+                    self.index.di_usages.add(
+                        uri,
+                        DiUsage {
+                            name: dep_name.clone(),
+                            span,
+                        },
+                    );
+
                     if !dep_name.starts_with('$') {
                         let reference = SymbolReference {
                             name: dep_name,
                             uri: uri.clone(),
-                            span: self.span_of(child),
+                            span,
                         };
 
                         self.index.definitions.add_reference(reference);
@@ -152,18 +165,30 @@ impl AngularJsAnalyzer {
     /// .controller('Ctrl', ['$scope', 'UserService', function(...) {}])
     /// ```
     ///
-    /// `$` で始まるAngular組み込みサービスはスキップ
+    /// `$` で始まるAngular組み込みサービスは `SymbolReference` 登録はスキップ。
+    /// 「未知サービス警告 (#63)」用には `$` 付きも含めて DI usage を記録する。
     pub(super) fn extract_dependencies(&self, node: Node, source: &str, uri: &Url) {
         if node.kind() == "array" {
             let mut cursor = node.walk();
             for child in node.children(&mut cursor) {
                 if child.kind() == "string" {
                     let dep_name = self.extract_string_value(child, source);
+                    let span = self.span_of(child);
+
+                    // 未知サービス警告用: $ 付きも含めて全 DI 文字列を記録
+                    self.index.di_usages.add(
+                        uri,
+                        DiUsage {
+                            name: dep_name.clone(),
+                            span,
+                        },
+                    );
+
                     if !dep_name.starts_with('$') {
                         let reference = SymbolReference {
                             name: dep_name,
                             uri: uri.clone(),
-                            span: self.span_of(child),
+                            span,
                         };
 
                         self.index.definitions.add_reference(reference);

--- a/src/config/ajs_config.rs
+++ b/src/config/ajs_config.rs
@@ -40,6 +40,11 @@ pub struct DiagnosticsConfig {
     /// 未使用スコープ変数の警告を有効にする（デフォルト: true）
     #[serde(default = "default_true")]
     pub unused_scope_variables: bool,
+    /// DI 配列内の未登録サービス名 (typo) 警告の重要度
+    /// "error" / "warning" / "hint" / "information" / "off" (デフォルト: "warning")
+    /// "off" を指定するとこの診断を無効化する。
+    #[serde(default = "default_unknown_di_service_severity")]
+    pub unknown_di_service_severity: String,
 }
 
 fn default_true() -> bool {
@@ -50,12 +55,17 @@ fn default_severity() -> String {
     "warning".to_string()
 }
 
+fn default_unknown_di_service_severity() -> String {
+    "warning".to_string()
+}
+
 impl Default for DiagnosticsConfig {
     fn default() -> Self {
         Self {
             enabled: default_true(),
             severity: default_severity(),
             unused_scope_variables: default_true(),
+            unknown_di_service_severity: default_unknown_di_service_severity(),
         }
     }
 }

--- a/src/handler/builtin_services.rs
+++ b/src/handler/builtin_services.rs
@@ -1,0 +1,248 @@
+//! AngularJS 1.x の組み込みサービス allowlist
+//!
+//! `$scope` / `$http` などコアモジュール由来のサービスや、ngRoute / ngResource /
+//! ngCookies / ngAnimate / ui-router といった同梱されることの多い拡張モジュール
+//! 由来のサービス・プロバイダ名を静的に列挙する。
+//!
+//! このリストはユーザー定義サービス (`.service('Foo', ...)` 等) や
+//! ワークスペース内で見つからなかったときに「組み込みかどうか」を判定するため
+//! に使う。`is_builtin_service` で完全一致判定する。
+//!
+//! 第三者ライブラリ等で追加された名前は ajsconfig.json で allowlist 拡張する
+//! 想定だが、現状は静的リストのみ。
+
+/// AngularJS 組み込みサービス・プロバイダの完全一致 allowlist
+const BUILTIN_SERVICES: &[&str] = &[
+    // --- core services ---
+    "$scope",
+    "$rootScope",
+    "$rootElement",
+    "$injector",
+    "$provide",
+    "$compile",
+    "$compileProvider",
+    "$controller",
+    "$controllerProvider",
+    "$parse",
+    "$interpolate",
+    "$interpolateProvider",
+    "$filter",
+    "$filterProvider",
+    "$http",
+    "$httpProvider",
+    "$httpBackend",
+    "$httpParamSerializer",
+    "$httpParamSerializerJQLike",
+    "$location",
+    "$locationProvider",
+    "$window",
+    "$document",
+    "$timeout",
+    "$interval",
+    "$q",
+    "$log",
+    "$logProvider",
+    "$exceptionHandler",
+    "$exceptionHandlerProvider",
+    "$cacheFactory",
+    "$templateCache",
+    "$templateRequest",
+    "$sce",
+    "$sceProvider",
+    "$sceDelegate",
+    "$sceDelegateProvider",
+    "$animate",
+    "$animateProvider",
+    "$animateCss",
+    "$anchorScroll",
+    "$anchorScrollProvider",
+    "$xhrFactory",
+    "$jsonpCallbacks",
+    "$browser",
+    // --- ngRoute ---
+    "$route",
+    "$routeProvider",
+    "$routeParams",
+    // --- ngResource ---
+    "$resource",
+    "$resourceProvider",
+    // --- ngCookies ---
+    "$cookies",
+    "$cookieStore",
+    "$cookiesProvider",
+    // --- ngTouch / ngSanitize ---
+    "$swipe",
+    "$sanitize",
+    "$sanitizeProvider",
+    // --- ui-router (1.x) ---
+    "$state",
+    "$stateProvider",
+    "$stateParams",
+    "$urlRouter",
+    "$urlRouterProvider",
+    "$urlMatcherFactory",
+    "$urlMatcherFactoryProvider",
+    "$transitions",
+    "$uiRouter",
+    "$uiRouterProvider",
+    "$uiViewScroll",
+    "$uiViewScrollProvider",
+];
+
+/// `name` が AngularJS 組み込みサービス名と完全一致するかどうか
+pub fn is_builtin_service(name: &str) -> bool {
+    BUILTIN_SERVICES.contains(&name)
+}
+
+/// `name` に「もしかして」候補となる組み込みサービス名を返す。
+/// Levenshtein 距離が `max_distance` 以下のもののみ対象。
+///
+/// 戻り値は最も距離が近いものを 1 件だけ返す。
+pub fn suggest_builtin_service(name: &str, max_distance: usize) -> Option<&'static str> {
+    let mut best: Option<(&'static str, usize)> = None;
+    for candidate in BUILTIN_SERVICES {
+        let d = levenshtein(name, candidate);
+        if d == 0 {
+            // 完全一致 (allowlist 内) は補正候補ではない
+            return None;
+        }
+        if d <= max_distance && best.map(|(_, bd)| d < bd).unwrap_or(true) {
+            best = Some((*candidate, d));
+        }
+    }
+    best.map(|(s, _)| s)
+}
+
+/// Levenshtein 距離を計算する (バイト単位 / ASCII 前提)。
+///
+/// AngularJS のサービス名は ASCII (英数 + `$`) の範囲なので、UTF-8 を意識する
+/// 必要はないがセーフティとして文字単位 (`chars()`) で扱う。空文字も許容。
+pub fn levenshtein(a: &str, b: &str) -> usize {
+    let a_chars: Vec<char> = a.chars().collect();
+    let b_chars: Vec<char> = b.chars().collect();
+    let n = a_chars.len();
+    let m = b_chars.len();
+    if n == 0 {
+        return m;
+    }
+    if m == 0 {
+        return n;
+    }
+
+    // 1 行ぶんの DP テーブルを使い回す
+    let mut prev: Vec<usize> = (0..=m).collect();
+    let mut curr: Vec<usize> = vec![0; m + 1];
+    for i in 1..=n {
+        curr[0] = i;
+        for j in 1..=m {
+            let cost = if a_chars[i - 1] == b_chars[j - 1] { 0 } else { 1 };
+            // 削除 / 挿入 / 置換 のうち最小
+            curr[j] = (prev[j] + 1)
+                .min(curr[j - 1] + 1)
+                .min(prev[j - 1] + cost);
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+    prev[m]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn levenshtein_same_string_is_zero() {
+        assert_eq!(levenshtein("$timeout", "$timeout"), 0);
+    }
+
+    #[test]
+    fn levenshtein_empty_left() {
+        assert_eq!(levenshtein("", "abc"), 3);
+    }
+
+    #[test]
+    fn levenshtein_empty_right() {
+        assert_eq!(levenshtein("abc", ""), 3);
+    }
+
+    #[test]
+    fn levenshtein_single_substitution() {
+        // $timeout vs $timoout = 1 substitution
+        assert_eq!(levenshtein("$timeout", "$timoout"), 1);
+    }
+
+    #[test]
+    fn levenshtein_transposition_counts_as_two() {
+        // 古典的な Levenshtein では transposition は 2 カウント
+        assert_eq!(levenshtein("$tiemout", "$timeout"), 2);
+    }
+
+    #[test]
+    fn levenshtein_insertion() {
+        assert_eq!(levenshtein("$http", "$https"), 1);
+    }
+
+    #[test]
+    fn levenshtein_deletion() {
+        assert_eq!(levenshtein("$scoope", "$scope"), 1);
+    }
+
+    #[test]
+    fn levenshtein_completely_different() {
+        // 完全に異なる文字列でも長さ差より大きくはならない
+        let d = levenshtein("$foo", "$timeout");
+        assert!((5..=8).contains(&d), "got {}", d);
+    }
+
+    #[test]
+    fn is_builtin_recognizes_core_services() {
+        assert!(is_builtin_service("$scope"));
+        assert!(is_builtin_service("$http"));
+        assert!(is_builtin_service("$timeout"));
+        assert!(is_builtin_service("$rootScope"));
+    }
+
+    #[test]
+    fn is_builtin_recognizes_ui_router() {
+        assert!(is_builtin_service("$state"));
+        assert!(is_builtin_service("$stateProvider"));
+        assert!(is_builtin_service("$stateParams"));
+    }
+
+    #[test]
+    fn is_builtin_rejects_user_services() {
+        assert!(!is_builtin_service("UserService"));
+        assert!(!is_builtin_service("$tiemout"));
+        assert!(!is_builtin_service(""));
+    }
+
+    #[test]
+    fn suggest_returns_close_match() {
+        // $tiemout (typo) → $timeout (距離2)
+        assert_eq!(
+            suggest_builtin_service("$tiemout", 2),
+            Some("$timeout")
+        );
+    }
+
+    #[test]
+    fn suggest_returns_none_for_unknown_unrelated() {
+        // 完全に別物には候補を出さない
+        assert_eq!(
+            suggest_builtin_service("MyCustomService", 2),
+            None
+        );
+    }
+
+    #[test]
+    fn suggest_does_not_match_exact_name() {
+        // 既に組み込みと一致しているなら「もしかして」は不要
+        assert_eq!(suggest_builtin_service("$timeout", 2), None);
+    }
+
+    #[test]
+    fn suggest_picks_closest_when_multiple_candidates() {
+        // $sccope (距離1で $scope に一致) — $sce (距離3) より近い
+        assert_eq!(suggest_builtin_service("$sccope", 2), Some("$scope"));
+    }
+}

--- a/src/handler/diagnostics.rs
+++ b/src/handler/diagnostics.rs
@@ -3,8 +3,13 @@ use std::sync::Arc;
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, DiagnosticTag, Position, Range, Url};
 use tracing::debug;
 
+use super::builtin_services::{is_builtin_service, suggest_builtin_service};
 use crate::config::DiagnosticsConfig;
 use crate::index::Index;
+use crate::model::SymbolKind;
+
+/// 未知サービス警告で「もしかして」候補とみなす最大 Levenshtein 距離
+const UNKNOWN_DI_SUGGEST_MAX_DISTANCE: usize = 2;
 
 /// 診断ハンドラー
 pub struct DiagnosticsHandler {
@@ -58,7 +63,108 @@ impl DiagnosticsHandler {
             diagnostics.extend(self.check_unused_scope_variables(uri));
         }
 
+        // 未登録サービス (typo) のチェック
+        diagnostics.extend(self.check_unknown_di_services(uri));
+
         diagnostics
+    }
+
+    /// `unknown_di_service_severity` 設定を `Option<DiagnosticSeverity>` に変換
+    /// "off" の場合は `None` (診断無効)
+    fn parse_unknown_di_severity(&self) -> Option<DiagnosticSeverity> {
+        match self.config.unknown_di_service_severity.to_lowercase().as_str() {
+            "off" | "none" | "disabled" | "false" => None,
+            "error" => Some(DiagnosticSeverity::ERROR),
+            "warning" => Some(DiagnosticSeverity::WARNING),
+            "hint" => Some(DiagnosticSeverity::HINT),
+            "information" | "info" => Some(DiagnosticSeverity::INFORMATION),
+            _ => Some(DiagnosticSeverity::WARNING),
+        }
+    }
+
+    /// DI 配列内の未登録サービス名 (typo) を検出する。
+    ///
+    /// 1. AngularJS 組み込みサービス allowlist と完全一致するか
+    /// 2. workspace の Service / Factory / Provider / Value / Constant 定義に存在するか
+    ///
+    /// どちらでもない要素について警告を生成する。Levenshtein 距離 2 以内の組み込み
+    /// サービス名があれば「もしかして `$timeout`?」をメッセージに含める。
+    ///
+    /// false positive を避けるため、workspace スキャン完了前は静かに何も返さない。
+    pub(crate) fn check_unknown_di_services(&self, uri: &Url) -> Vec<Diagnostic> {
+        // 設定で無効化されていれば何もしない
+        let Some(severity) = self.parse_unknown_di_severity() else {
+            return Vec::new();
+        };
+
+        // workspace 全体の解析が終わるまでは workspace 由来サービスが揃わないので
+        // false positive を避けるため黙る (ユーザ視点では「起動直後だけ静か」)
+        if !self.index.is_workspace_scanned() {
+            return Vec::new();
+        }
+
+        let usages = self.index.di_usages.get_for_uri(uri);
+        if usages.is_empty() {
+            return Vec::new();
+        }
+
+        let mut diagnostics = Vec::new();
+        for usage in usages {
+            // 1. 組み込み allowlist
+            if is_builtin_service(&usage.name) {
+                continue;
+            }
+            // 2. workspace の Service / Factory / Provider / Value / Constant 定義
+            if self.is_known_workspace_service(&usage.name) {
+                continue;
+            }
+
+            // 候補生成: 組み込みサービスから Levenshtein ≤ 2 のものを 1 件提案
+            let mut message = format!("Unknown service '{}' in DI array", usage.name);
+            if let Some(suggestion) =
+                suggest_builtin_service(&usage.name, UNKNOWN_DI_SUGGEST_MAX_DISTANCE)
+            {
+                message.push_str(&format!(". Did you mean '{}'?", suggestion));
+            }
+
+            diagnostics.push(Diagnostic {
+                range: Range {
+                    start: Position {
+                        line: usage.span.start_line,
+                        character: usage.span.start_col,
+                    },
+                    end: Position {
+                        line: usage.span.end_line,
+                        character: usage.span.end_col,
+                    },
+                },
+                severity: Some(severity),
+                code: None,
+                code_description: None,
+                source: Some("angularjs-lsp".to_string()),
+                message,
+                related_information: None,
+                tags: None,
+                data: None,
+            });
+        }
+
+        diagnostics
+    }
+
+    /// `name` が workspace 内の Service / Factory / Provider / Value / Constant
+    /// 定義のいずれかに該当するか
+    fn is_known_workspace_service(&self, name: &str) -> bool {
+        const KINDS: &[SymbolKind] = &[
+            SymbolKind::Service,
+            SymbolKind::Factory,
+            SymbolKind::Provider,
+            SymbolKind::Value,
+            SymbolKind::Constant,
+        ];
+        KINDS
+            .iter()
+            .any(|k| self.index.definitions.has_definition_of_kind(name, *k))
     }
 
     /// 未使用スコープ変数をチェックし警告生成

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -1,3 +1,4 @@
+mod builtin_services;
 mod codelens;
 mod completion;
 mod definition;

--- a/src/index/di_usage_store.rs
+++ b/src/index/di_usage_store.rs
@@ -1,0 +1,149 @@
+//! DI 配列の string literal を URI ごとに保持するストア
+//!
+//! `extract_dependencies` はユーザ定義サービスのみ `SymbolReference` として
+//! 登録し、`$` 始まりの組み込みサービスはスキップする。一方、未登録サービス
+//! 警告 (issue #63) では `$tiemout` のような `$` 付き typo も検出したいので、
+//! DI 配列で書かれた string literal を生のまま保存しておく必要がある。
+//!
+//! 本ストアは「未知サービス警告」用に閉じたデータを持つ：
+//! - URI 単位で全 DI usage を保持
+//! - `clear_document` で当該 URI 分だけ消す
+//! - 順序保持・重複は許容 (位置で識別)
+
+use dashmap::DashMap;
+use tower_lsp::lsp_types::Url;
+
+use crate::model::Span;
+
+/// DI 配列内に出現した 1 個の string literal
+#[derive(Debug, Clone)]
+pub struct DiUsage {
+    /// 文字列リテラルの中身 (例: `$scope`, `UserService`, `$tiemout`)
+    pub name: String,
+    /// 文字列リテラル全体の位置 (クォート込み)
+    pub span: Span,
+}
+
+/// DI 配列内の string literal を URI 単位で蓄積するストア
+pub struct DiUsageStore {
+    usages: DashMap<Url, Vec<DiUsage>>,
+}
+
+impl DiUsageStore {
+    pub fn new() -> Self {
+        Self {
+            usages: DashMap::new(),
+        }
+    }
+
+    /// `uri` に DI usage を 1 件追加する
+    pub fn add(&self, uri: &Url, usage: DiUsage) {
+        self.usages
+            .entry(uri.clone())
+            .or_default()
+            .push(usage);
+    }
+
+    /// 指定 URI の DI usage を全件取得する (clone)
+    pub fn get_for_uri(&self, uri: &Url) -> Vec<DiUsage> {
+        self.usages
+            .get(uri)
+            .map(|v| v.value().clone())
+            .unwrap_or_default()
+    }
+
+    pub fn clear_document(&self, uri: &Url) {
+        self.usages.remove(uri);
+    }
+
+    pub fn clear_all(&self) {
+        self.usages.clear();
+    }
+}
+
+impl Default for DiUsageStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn span(line: u32) -> Span {
+        Span::new(line, 0, line, 5)
+    }
+
+    #[test]
+    fn add_and_get_for_uri_returns_usages_in_order() {
+        let store = DiUsageStore::new();
+        let uri = Url::parse("file:///a.js").unwrap();
+        store.add(
+            &uri,
+            DiUsage {
+                name: "$scope".into(),
+                span: span(1),
+            },
+        );
+        store.add(
+            &uri,
+            DiUsage {
+                name: "$tiemout".into(),
+                span: span(2),
+            },
+        );
+
+        let usages = store.get_for_uri(&uri);
+        assert_eq!(usages.len(), 2);
+        assert_eq!(usages[0].name, "$scope");
+        assert_eq!(usages[1].name, "$tiemout");
+    }
+
+    #[test]
+    fn get_for_uri_returns_empty_when_unknown() {
+        let store = DiUsageStore::new();
+        let uri = Url::parse("file:///unknown.js").unwrap();
+        assert!(store.get_for_uri(&uri).is_empty());
+    }
+
+    #[test]
+    fn clear_document_drops_only_target_uri() {
+        let store = DiUsageStore::new();
+        let uri_a = Url::parse("file:///a.js").unwrap();
+        let uri_b = Url::parse("file:///b.js").unwrap();
+        store.add(
+            &uri_a,
+            DiUsage {
+                name: "X".into(),
+                span: span(1),
+            },
+        );
+        store.add(
+            &uri_b,
+            DiUsage {
+                name: "Y".into(),
+                span: span(1),
+            },
+        );
+
+        store.clear_document(&uri_a);
+        assert!(store.get_for_uri(&uri_a).is_empty());
+        assert_eq!(store.get_for_uri(&uri_b).len(), 1);
+    }
+
+    #[test]
+    fn clear_all_drops_all_usages() {
+        let store = DiUsageStore::new();
+        let uri_a = Url::parse("file:///a.js").unwrap();
+        store.add(
+            &uri_a,
+            DiUsage {
+                name: "X".into(),
+                span: span(1),
+            },
+        );
+        store.clear_all();
+        assert!(store.get_for_uri(&uri_a).is_empty());
+    }
+}

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -1,6 +1,7 @@
 pub mod component_store;
 pub mod controller_store;
 pub mod definition_store;
+pub mod di_usage_store;
 pub mod export_store;
 pub mod html_resolve;
 pub mod html_store;
@@ -13,14 +14,16 @@ pub use html_resolve::HtmlResolution;
 pub use component_store::ComponentStore;
 pub use controller_store::ControllerStore;
 pub use definition_store::DefinitionStore;
+pub use di_usage_store::{DiUsage, DiUsageStore};
 pub use export_store::ExportStore;
 pub use html_store::HtmlStore;
 pub use interpolate_store::InterpolateStore;
 pub use template_store::TemplateStore;
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use tower_lsp::lsp_types::Url;
 
-/// Index ファサード — 7つの専門ストアを束ねる
+/// Index ファサード — 8つの専門ストアを束ねる
 pub struct Index {
     pub definitions: DefinitionStore,
     pub controllers: ControllerStore,
@@ -29,6 +32,12 @@ pub struct Index {
     pub exports: ExportStore,
     pub components: ComponentStore,
     pub interpolate: InterpolateStore,
+    pub di_usages: DiUsageStore,
+    /// workspace の初回スキャンが完了したか。
+    ///
+    /// 「未知サービス警告 (#63)」のように workspace 全シンボルが揃わないと false
+    /// positive を出してしまう診断は、このフラグが true になるまで黙る。
+    workspace_scanned: AtomicBool,
 }
 
 impl Index {
@@ -41,7 +50,19 @@ impl Index {
             exports: ExportStore::new(),
             components: ComponentStore::new(),
             interpolate: InterpolateStore::new(),
+            di_usages: DiUsageStore::new(),
+            workspace_scanned: AtomicBool::new(false),
         }
+    }
+
+    /// workspace スキャン完了をマークする (false positive 抑制用)
+    pub fn mark_workspace_scanned(&self) {
+        self.workspace_scanned.store(true, Ordering::Release);
+    }
+
+    /// workspace スキャン完了済みかどうか
+    pub fn is_workspace_scanned(&self) -> bool {
+        self.workspace_scanned.load(Ordering::Acquire)
     }
 
     /// 指定URIの全データをクリア
@@ -53,6 +74,7 @@ impl Index {
         self.exports.clear_document(uri);
         self.components.clear_document(uri);
         self.interpolate.clear_document(uri);
+        self.di_usages.clear_document(uri);
     }
 
     /// 全てのインデックスデータをクリア
@@ -64,6 +86,7 @@ impl Index {
         self.exports.clear_all();
         self.components.clear_all();
         self.interpolate.clear_all();
+        self.di_usages.clear_all();
     }
 
     /// HTML参照情報のみをクリア（Pass 3で収集する情報）

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1191,6 +1191,11 @@ impl Backend {
                     )
                     .await;
 
+                // workspace スキャン完了をマーク。
+                // 「未知サービス警告 (#63)」のように workspace 全シンボルが
+                // 揃ってから判定したい診断はこのフラグを参照する。
+                self.index.mark_workspace_scanned();
+
                 self.republish_diagnostics_for_open_js_files().await;
 
                 end_progress(
@@ -1682,6 +1687,10 @@ impl LanguageServer for Backend {
         // workspace scan / cache load 完了後、既に開いていたファイルに対して
         // 解析 + 診断 + refresh を最終確定させる (初期化順の race と
         // disk-vs-buffer 不整合を解消)
+        // 「未知サービス警告 (#63)」のように workspace 全シンボルを揃えてから
+        // 判定したい診断のために、ここで scan 完了をマークする (cache load
+        // パスでも確実に true になる)
+        self.index.mark_workspace_scanned();
         self.republish_open_files_after_init().await;
     }
 

--- a/tests/diagnose_unknown_di_service_test.rs
+++ b/tests/diagnose_unknown_di_service_test.rs
@@ -1,0 +1,330 @@
+//! `check_unknown_di_services` (issue #63) の統合テスト
+//!
+//! DI 配列内の string literal について:
+//! 1. AngularJS 組み込みサービス allowlist と完全一致するなら静か
+//! 2. workspace の Service / Factory / Provider / Value / Constant 定義に
+//!    存在するなら静か
+//! 3. どちらでもなければ警告。Levenshtein 距離 ≤ 2 の組み込みサービスがあれば
+//!    "Did you mean '...'?" を message に含める
+//!
+//! workspace スキャン未完了時は静か (起動直後の false positive を抑止) も検証する。
+
+use std::sync::Arc;
+
+use tower_lsp::lsp_types::{DiagnosticSeverity, Url};
+
+use angularjs_lsp::analyzer::js::AngularJsAnalyzer;
+use angularjs_lsp::config::DiagnosticsConfig;
+use angularjs_lsp::handler::DiagnosticsHandler;
+use angularjs_lsp::index::Index;
+
+fn js_uri() -> Url {
+    Url::parse("file:///test.js").unwrap()
+}
+
+/// JS ソースを解析し、workspace scan 完了済み状態の Index を返す
+fn analyze_and_mark_scanned(js_source: &str) -> Arc<Index> {
+    let index = Arc::new(Index::new());
+    let analyzer = AngularJsAnalyzer::new(Arc::clone(&index));
+    analyzer.analyze_document(&js_uri(), js_source);
+    index.mark_workspace_scanned();
+    index
+}
+
+fn diagnose(index: Arc<Index>, uri: &Url) -> Vec<tower_lsp::lsp_types::Diagnostic> {
+    let handler = DiagnosticsHandler::new(index, DiagnosticsConfig::default());
+    handler.diagnose_js(uri)
+}
+
+#[test]
+fn allowlist_builtin_service_is_silent() {
+    // $scope / $http / $timeout は組み込みなので警告にならない
+    let js = r#"
+angular.module('app', [])
+.controller('MyCtrl', ['$scope', '$http', '$timeout', function($scope, $http, $timeout) {
+    $scope.go = function() {};
+}]);
+"#;
+    let index = analyze_and_mark_scanned(js);
+    let diagnostics = diagnose(index, &js_uri());
+
+    // 未知サービス警告のみフィルタ
+    let unknown_diags: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.message.starts_with("Unknown service"))
+        .collect();
+    assert!(
+        unknown_diags.is_empty(),
+        "組み込みサービスは警告にならないはず: {:?}",
+        unknown_diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn known_workspace_service_is_silent() {
+    // 同じファイル内に登録された UserService は警告にならない
+    let js = r#"
+angular.module('app', [])
+.service('UserService', function() {
+    this.fetch = function() {};
+})
+.controller('MyCtrl', ['$scope', 'UserService', function($scope, UserService) {
+    $scope.u = UserService;
+}]);
+"#;
+    let index = analyze_and_mark_scanned(js);
+    let diagnostics = diagnose(index, &js_uri());
+
+    let unknown_diags: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.message.starts_with("Unknown service"))
+        .collect();
+    assert!(
+        unknown_diags.is_empty(),
+        "登録済み workspace サービスは警告にならないはず: {:?}",
+        unknown_diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn known_workspace_factory_is_silent() {
+    let js = r#"
+angular.module('app', [])
+.factory('AuthFactory', function() { return {}; })
+.controller('MyCtrl', ['AuthFactory', function(AuthFactory) {}]);
+"#;
+    let index = analyze_and_mark_scanned(js);
+    let diagnostics = diagnose(index, &js_uri());
+
+    let unknown_diags: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.message.starts_with("Unknown service"))
+        .collect();
+    assert!(unknown_diags.is_empty());
+}
+
+#[test]
+fn known_workspace_value_and_constant_are_silent() {
+    let js = r#"
+angular.module('app', [])
+.value('appConfig', { foo: 1 })
+.constant('API_URL', '/api')
+.controller('MyCtrl', ['appConfig', 'API_URL', function(c, u) {}]);
+"#;
+    let index = analyze_and_mark_scanned(js);
+    let diagnostics = diagnose(index, &js_uri());
+
+    let unknown_diags: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.message.starts_with("Unknown service"))
+        .collect();
+    assert!(unknown_diags.is_empty(), "Value / Constant は警告にならないはず");
+}
+
+#[test]
+fn typo_of_builtin_service_is_warned_with_suggestion() {
+    // $tiemout (typo) は $timeout と Levenshtein 距離 2 → "Did you mean '$timeout'?"
+    let js = r#"
+angular.module('app', [])
+.controller('MyCtrl', ['$scope', '$tiemout', function($scope, t) {
+    t(function() {}, 100);
+}]);
+"#;
+    let index = analyze_and_mark_scanned(js);
+    let diagnostics = diagnose(index, &js_uri());
+
+    let unknown_diags: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.message.starts_with("Unknown service"))
+        .collect();
+
+    assert_eq!(
+        unknown_diags.len(),
+        1,
+        "$tiemout 1件のみ警告のはず。実際: {:?}",
+        unknown_diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    let msg = &unknown_diags[0].message;
+    assert!(
+        msg.contains("$tiemout"),
+        "メッセージにユーザの書いた名前を含めるべき: {}",
+        msg
+    );
+    assert!(
+        msg.contains("$timeout"),
+        "Levenshtein 候補 $timeout を含めるべき: {}",
+        msg
+    );
+    assert!(
+        msg.contains("Did you mean"),
+        "メッセージに 'Did you mean' を含めるべき: {}",
+        msg
+    );
+    assert_eq!(
+        unknown_diags[0].severity,
+        Some(DiagnosticSeverity::WARNING)
+    );
+}
+
+#[test]
+fn completely_unknown_service_is_warned_without_suggestion() {
+    // どの組み込みサービスとも遠い名前なら "Did you mean" は付かない
+    let js = r#"
+angular.module('app', [])
+.controller('MyCtrl', ['CompletelyUnknownXyz', function(x) {}]);
+"#;
+    let index = analyze_and_mark_scanned(js);
+    let diagnostics = diagnose(index, &js_uri());
+
+    let unknown_diags: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.message.starts_with("Unknown service"))
+        .collect();
+
+    assert_eq!(unknown_diags.len(), 1);
+    let msg = &unknown_diags[0].message;
+    assert!(msg.contains("CompletelyUnknownXyz"));
+    assert!(
+        !msg.contains("Did you mean"),
+        "遠すぎる名前には候補を出さない: {}",
+        msg
+    );
+}
+
+#[test]
+fn silent_until_workspace_scan_completed() {
+    // mark_workspace_scanned を呼ばない → 警告は一切出ない (false positive 抑止)
+    let js = r#"
+angular.module('app', [])
+.controller('MyCtrl', ['$tiemout', 'Unknown', function(a, b) {}]);
+"#;
+    let index = Arc::new(Index::new());
+    let analyzer = AngularJsAnalyzer::new(Arc::clone(&index));
+    analyzer.analyze_document(&js_uri(), js);
+    // ★ ここで mark_workspace_scanned() を呼ばない
+
+    let diagnostics = diagnose(index, &js_uri());
+
+    let unknown_diags: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.message.starts_with("Unknown service"))
+        .collect();
+    assert!(
+        unknown_diags.is_empty(),
+        "scan 未完了の状態では警告は出ないはず: {:?}",
+        unknown_diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn inject_pattern_typo_is_warned() {
+    // `MyCtrl.$inject = [...]` パターンでも typo が検出されるか
+    let js = r#"
+function MyCtrl(s, t) {}
+MyCtrl.$inject = ['$scope', '$tiemout'];
+angular.module('app', []).controller('MyCtrl', MyCtrl);
+"#;
+    let index = analyze_and_mark_scanned(js);
+    let diagnostics = diagnose(index, &js_uri());
+
+    let unknown_diags: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.message.starts_with("Unknown service"))
+        .collect();
+    assert!(
+        !unknown_diags.is_empty(),
+        "$inject 経由でも typo を検出すべき"
+    );
+    assert!(unknown_diags.iter().any(|d| d.message.contains("$timeout")));
+}
+
+#[test]
+fn severity_off_disables_diagnostic() {
+    let js = r#"
+angular.module('app', [])
+.controller('MyCtrl', ['$tiemout', function(t) {}]);
+"#;
+    let index = analyze_and_mark_scanned(js);
+
+    let config = DiagnosticsConfig {
+        unknown_di_service_severity: "off".to_string(),
+        ..Default::default()
+    };
+
+    let handler = DiagnosticsHandler::new(index, config);
+    let diagnostics = handler.diagnose_js(&js_uri());
+    let unknown_diags: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.message.starts_with("Unknown service"))
+        .collect();
+    assert!(
+        unknown_diags.is_empty(),
+        "severity=off で診断は無効化されるはず"
+    );
+}
+
+#[test]
+fn severity_error_changes_diagnostic_severity() {
+    let js = r#"
+angular.module('app', [])
+.controller('MyCtrl', ['CompletelyUnknownAbc', function(x) {}]);
+"#;
+    let index = analyze_and_mark_scanned(js);
+
+    let config = DiagnosticsConfig {
+        unknown_di_service_severity: "error".to_string(),
+        ..Default::default()
+    };
+
+    let handler = DiagnosticsHandler::new(index, config);
+    let diagnostics = handler.diagnose_js(&js_uri());
+
+    let unknown_diags: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.message.starts_with("Unknown service"))
+        .collect();
+    assert_eq!(unknown_diags.len(), 1);
+    assert_eq!(unknown_diags[0].severity, Some(DiagnosticSeverity::ERROR));
+}
+
+#[test]
+fn diagnostic_range_points_at_string_literal() {
+    let js = "angular.module('app', []).controller('C', ['$tiemout', function(t){}]);";
+    let index = analyze_and_mark_scanned(js);
+    let diagnostics = diagnose(index, &js_uri());
+
+    let unknown_diags: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.message.starts_with("Unknown service"))
+        .collect();
+    assert_eq!(unknown_diags.len(), 1);
+
+    // 範囲は '$tiemout' (クォート込み) を指しているはず
+    let range = unknown_diags[0].range;
+    assert_eq!(range.start.line, 0);
+    assert_eq!(range.end.line, 0);
+    let snippet = &js[range.start.character as usize..range.end.character as usize];
+    assert_eq!(snippet, "'$tiemout'");
+}
+
+#[test]
+fn typo_of_user_service_is_still_warned_when_no_close_builtin() {
+    // ユーザ定義 UserService に対する typo `UserServce` は組み込み候補が無いので
+    // (Levenshtein で組み込みサービスに近いものが無い) "Unknown service" になる。
+    // 候補提案は組み込みのみが対象なので "Did you mean" は付かない。
+    let js = r#"
+angular.module('app', [])
+.service('UserService', function() {})
+.controller('MyCtrl', ['UserServce', function(u) {}]);
+"#;
+    let index = analyze_and_mark_scanned(js);
+    let diagnostics = diagnose(index, &js_uri());
+
+    let unknown_diags: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.message.starts_with("Unknown service"))
+        .collect();
+    assert_eq!(unknown_diags.len(), 1);
+    let msg = &unknown_diags[0].message;
+    assert!(msg.contains("UserServce"));
+}


### PR DESCRIPTION
## Summary
- DI 配列の string literal を解析し、組み込みサービス allowlist にも workspace の Service / Factory / Provider / Value / Constant 定義にも該当しない名前を警告する診断を追加 (#63)
- Levenshtein 距離 ≤ 2 の組み込みサービスがあれば「もしかして `$timeout`?」をメッセージに含める
- workspace 初回スキャン完了前は静かにして false positive を抑止する (`Index::workspace_scanned` フラグを追加)
- `DiagnosticsConfig.unknown_di_service_severity` で重要度切替 / `"off"` 指定で無効化可能

## 主な変更
- `src/handler/builtin_services.rs` (新規): 組み込みサービス allowlist + Levenshtein 関数
- `src/index/di_usage_store.rs` (新規): DI 配列内の string literal を URI ごとに保存 (`$` 付きも含む)
- `src/handler/diagnostics.rs`: `check_unknown_di_services` を追加し `diagnose_js` から呼ぶ
- `src/analyzer/js/di.rs`: `extract_dependencies` / `extract_inject_dependencies` を拡張して `DiUsageStore` に登録 (既存の参照登録パスは変更なし)
- `src/config/ajs_config.rs`: `unknown_di_service_severity` を追加 (デフォルト `"warning"`)
- `src/server/mod.rs`: workspace スキャン / cache load 完了で `mark_workspace_scanned` を呼ぶ

## Test plan
- [x] `cargo build` 警告ゼロ
- [x] `cargo test` 全通過 (既存 532 件 + 新規 31 件 = 563 件)
  - 単体: `builtin_services` 15 件 (Levenshtein 距離 / allowlist / suggest 対称性)
  - 単体: `di_usage_store` 4 件
  - 統合: `tests/diagnose_unknown_di_service_test.rs` 12 件
    - allowlist 内サービスは静か
    - workspace 登録済みサービス (Service / Factory / Value / Constant) は静か
    - typo (`$tiemout`) → `Did you mean '$timeout'?` 付きで警告
    - 完全に未知の名前は候補なしで警告
    - workspace スキャン完了前は警告なし
    - `$inject = [...]` パターンでも typo 検出
    - severity 設定 (`"off"` / `"error"`) が効く
    - 警告範囲は string literal のクォート込み

🤖 Generated with [Claude Code](https://claude.com/claude-code)