### PR TITLE
chore: release v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "angularjs-lsp"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "bincode",
  "dashmap 6.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "angularjs-lsp"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 authors = ["mochi"]
 description = "Language Server Protocol implementation for AngularJS 1.x"

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Change Log
 
+## [0.4.0] - 2026-05-06
+
+### Features
+- Inlay hints で DI alias と controller as の隠れた束縛を可視化 (PR #78)
+- Document highlight: カーソル位置の同名シンボルを同ファイル内でハイライト (PR #77, #81)
+- Signature help を実装 (PR #72)
+- Rename refactoring を実装 (PR #71)
+- DI 配列の要素数と関数の引数数の不一致を診断で警告 (PR #73)
+
+### Performance
+- did_open / initialized 後の `semantic_tokens_refresh` を診断発行と並列化 (PR #60)
+- Inlay hints の JS Tree をキャッシュして再パースを省略 (PR #78)
+
+### Refactor
+- `scope_reference.rs` の UTF-16 walker を `position_in_text` に共通化 (PR #50)
+- HTML ハンドラ三兄弟の位置解決ロジックを `HtmlResolution` で統合 (PR #49)
+- `scope_reference.rs` から ui-sref / ng-model 処理を別モジュールへ分離 (PR #48)
+- receiver 判定を `ReceiverMatch` enum で統合 (PR #46)
+- route/state の config 解析を `ConfigKind` enum で統合 (PR #47)
+- `span_of` helper を導入し Node→Span 変換を整理
+
+### Reverted
+- 未登録 directive / component の使用を診断で警告する機能 (PR #75) を revert (PR #83)
+- component bindings と HTML 属性の対応漏れを警告する診断 (PR #79) を revert (PR #82)
+
 ## [0.3.1] - 2026-04-30
 
 ### Fixes

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "angularjs-lsp",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "angularjs-lsp",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "angularjs-lsp",
   "displayName": "AngularJS 1.x IntelliSense",
   "description": "Language Server Protocol implementation for AngularJS 1.x projects",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "icon": "icon.png",
   "publisher": "mochi33",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- v0.3.1 → v0.4.0 へバージョンを更新
- Cargo.toml / vscode-extension/package.json / package-lock.json / Cargo.lock を v0.4.0 に bump
- vscode-extension/CHANGELOG.md に v0.4.0 セクションを追記

## Highlights since v0.3.1
- **Features**: inlay hints (DI alias / controller as)、document highlight、signature help、rename refactoring、DI arity diagnostic
- **Perf**: semantic_tokens_refresh の並列化、inlay hints の JS Tree キャッシュ
- **Refactor**: scope_reference の UTF-16 walker 共通化、HTML 位置解決の統合、receiver 判定の enum 化 等
- **Reverted**: 未登録 directive 警告 (#75)、bindings mismatch 警告 (#79)

## Release flow
マージ後に \`v0.4.0\` タグを打って push すると \`release.yml\` が走り、各プラットフォーム向けバイナリと VSIX をリリースに添付します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)