### PR TITLE
fix: .component({controller: Identifier}) で関数宣言を Controller として登録

### DIFF
--- a/src/analyzer/js/component.rs
+++ b/src/analyzer/js/component.rs
@@ -327,6 +327,14 @@ impl AngularJsAnalyzer {
             (controller_name.as_ref(), controller_function_node)
         {
             self.extract_controller_methods(func_node, source, uri, name);
+
+            // identifier 参照 (`controller: FooCtrl` / `controller: ['$dep', FooCtrl]`)
+            // の場合、参照先の関数/class 宣言を Controller シンボルとして登録する。
+            // .controller() 経由の登録がない場合でも CodeLens / goto-def が解決できるように。
+            // (route/state/views/modal/dialog 全部このパスを通る)
+            if func_node.kind() == "identifier" {
+                self.register_inline_controller_definition(func_node, source, uri, name);
+            }
         }
 
         // TemplateBinding（双方向ジャンプ用）

--- a/src/analyzer/js/component.rs
+++ b/src/analyzer/js/component.rs
@@ -1043,6 +1043,52 @@ impl AngularJsAnalyzer {
         }
     }
 
+    /// `.component({ controller: Identifier })` の Identifier が指す
+    /// 同一ファイル内の `function Identifier(...)` / `class Identifier {...}` 宣言を
+    /// Controller シンボルとして登録する。
+    ///
+    /// `.controller('Name', Identifier)` 形式は `extract_component_definition` 経由で
+    /// 関数宣言の位置に Controller を登録するが、`.component()` の identifier 参照には
+    /// 同等の登録がなく、CodeLens / goto definition が "(not found)" になっていた。
+    fn register_inline_controller_definition(&self, ident_node: Node, source: &str, uri: &Url, name: &str) {
+        // ルートノードまで遡る (DashMap の同期コストを避けるため、ここで登録は
+        // 1 シンボルに限定する)
+        let mut root = ident_node;
+        while let Some(parent) = root.parent() {
+            root = parent;
+        }
+
+        let (start, end) = if let Some(func_decl) = self.find_function_declaration(root, source, name) {
+            (func_decl.start_position(), func_decl.end_position())
+        } else if let Some(class_decl) = self.find_class_declaration(root, source, name) {
+            // class 宣言の場合は constructor があればその位置、なければ class 全体
+            if let Some(constructor) = self.get_constructor_from_class(class_decl, source) {
+                (constructor.start_position(), constructor.end_position())
+            } else {
+                (class_decl.start_position(), class_decl.end_position())
+            }
+        } else {
+            return;
+        };
+
+        let def_span = Span::new(
+            self.offset_line(start.row as u32),
+            start.column as u32,
+            self.offset_line(end.row as u32),
+            end.column as u32,
+        );
+        let name_span = self.span_of(ident_node);
+        let docs = self.extract_jsdoc_for_line(start.row, source);
+
+        let mut builder = SymbolBuilder::new(name.to_string(), SymbolKind::Controller, uri.clone())
+            .definition_span(def_span)
+            .name_span(name_span);
+        if let Some(docs_str) = docs {
+            builder = builder.docs(docs_str);
+        }
+        self.index.definitions.add_definition(builder.build());
+    }
+
     /// コンポーネント設定オブジェクトから templateUrl, controller, controllerAs, bindings を抽出
     fn extract_component_template_url(&self, config_node: Node, source: &str, uri: &Url, component_name: Option<&str>) {
         let mut template_path: Option<String> = None;
@@ -1076,7 +1122,9 @@ impl AngularJsAnalyzer {
                                 }
                                 // controller: ControllerName (識別子参照)
                                 else if value.kind() == "identifier" {
-                                    controller_name = Some(self.node_text(value, source).to_string());
+                                    let name = self.node_text(value, source).to_string();
+                                    self.register_inline_controller_definition(value, source, uri, &name);
+                                    controller_name = Some(name);
                                 }
                                 // controller: ['$dep1', '$dep2', ControllerName] (DI配列パターン)
                                 else if value.kind() == "array" {
@@ -1090,7 +1138,9 @@ impl AngularJsAnalyzer {
                                     }
                                     if let Some(last) = last_element {
                                         if last.kind() == "identifier" {
-                                            controller_name = Some(self.node_text(last, source).to_string());
+                                            let name = self.node_text(last, source).to_string();
+                                            self.register_inline_controller_definition(last, source, uri, &name);
+                                            controller_name = Some(name);
                                         }
                                         // 最後の要素が function/class の場合はNone（インラインコントローラー）
                                     }

--- a/src/analyzer/js/tests/mod.rs
+++ b/src/analyzer/js/tests/mod.rs
@@ -974,6 +974,62 @@ angular.module('app', [])
     assert!(has_definition(&index, "userList", SymbolKind::Component));
 }
 
+#[test]
+fn test_component_with_identifier_controller_registers_function_as_controller() {
+    // .component({ controller: Identifier }) で identifier が同一ファイル内の
+    // function 宣言を指す場合、その関数を Controller シンボルとして登録する。
+    // この登録がないと CodeLens が "Component: Foo (not found)" を表示してしまう。
+    let index = analyze(
+        r#"
+(function() {
+    'use strict';
+    angular.module('app', [])
+    .component('formSelector', {
+        templateUrl: 'form_selector.html',
+        controller: FormSelectorController,
+        controllerAs: 'formSelector',
+    });
+
+    function FormSelectorController() {
+        var vm = this;
+        vm.placeholder = '';
+    }
+}());
+"#,
+    );
+
+    assert!(has_definition(&index, "formSelector", SymbolKind::Component));
+    assert!(
+        has_definition(&index, "FormSelectorController", SymbolKind::Controller),
+        "function declaration referenced as `controller: FormSelectorController` should be registered as Controller"
+    );
+}
+
+#[test]
+fn test_component_with_di_array_identifier_controller_registers_class() {
+    // .component({ controller: ['$dep', MyCtrl] }) で末尾識別子が class 宣言を指す場合も
+    // Controller シンボルとして登録する
+    let index = analyze(
+        r#"
+angular.module('app', [])
+.component('myComp', {
+    templateUrl: 'my-comp.html',
+    controller: ['$scope', MyCompController],
+    controllerAs: 'vm',
+});
+
+class MyCompController {
+    constructor($scope) {
+        this.scope = $scope;
+    }
+}
+"#,
+    );
+
+    assert!(has_definition(&index, "myComp", SymbolKind::Component));
+    assert!(has_definition(&index, "MyCompController", SymbolKind::Controller));
+}
+
 // ==========================================================================
 // 複合テスト: sample.js フィクスチャ相当
 // ==========================================================================

--- a/src/analyzer/js/tests/mod.rs
+++ b/src/analyzer/js/tests/mod.rs
@@ -1006,6 +1006,105 @@ fn test_component_with_identifier_controller_registers_function_as_controller() 
 }
 
 #[test]
+fn test_uib_modal_with_identifier_controller_registers_function() {
+    // $uibModal.open({ controller: Identifier }) でも同じ問題が起きるので
+    // 同様に Controller シンボル登録が必要
+    let index = analyze(
+        r#"
+function showDialog($uibModal) {
+    $uibModal.open({
+        templateUrl: 'dialog.html',
+        controller: DialogCtrl,
+    });
+}
+
+function DialogCtrl($scope) {
+    $scope.ok = function() {};
+}
+"#,
+    );
+
+    assert!(
+        has_definition(&index, "DialogCtrl", SymbolKind::Controller),
+        "function declaration referenced as `controller: DialogCtrl` in $uibModal.open should be registered as Controller"
+    );
+}
+
+#[test]
+fn test_route_provider_with_identifier_controller_registers_function() {
+    let index = analyze(
+        r#"
+angular.module('app', [])
+.config(function($routeProvider) {
+    $routeProvider.when('/home', {
+        templateUrl: 'home.html',
+        controller: HomeCtrl,
+    });
+});
+
+function HomeCtrl($scope) {
+    $scope.title = 'home';
+}
+"#,
+    );
+
+    assert!(has_definition(&index, "HomeCtrl", SymbolKind::Controller));
+}
+
+#[test]
+fn test_state_provider_with_identifier_controller_registers_function() {
+    let index = analyze(
+        r#"
+angular.module('app', [])
+.config(function($stateProvider) {
+    $stateProvider.state('home', {
+        url: '/home',
+        templateUrl: 'home.html',
+        controller: HomeCtrl,
+    });
+});
+
+function HomeCtrl($scope) {
+    $scope.title = 'home';
+}
+"#,
+    );
+
+    assert!(has_definition(&index, "HomeCtrl", SymbolKind::Controller));
+}
+
+#[test]
+fn test_state_provider_named_views_with_identifier_controller_registers_function() {
+    // $stateProvider.state('name', { views: { main: { controller: Identifier } } })
+    let index = analyze(
+        r#"
+angular.module('app', [])
+.config(function($stateProvider) {
+    $stateProvider.state('layout', {
+        url: '/layout',
+        views: {
+            'main@': {
+                templateUrl: 'main.html',
+                controller: MainCtrl,
+            },
+            'sidebar@': {
+                templateUrl: 'sidebar.html',
+                controller: SidebarCtrl,
+            },
+        },
+    });
+});
+
+function MainCtrl() {}
+function SidebarCtrl() {}
+"#,
+    );
+
+    assert!(has_definition(&index, "MainCtrl", SymbolKind::Controller));
+    assert!(has_definition(&index, "SidebarCtrl", SymbolKind::Controller));
+}
+
+#[test]
 fn test_component_with_di_array_identifier_controller_registers_class() {
     // .component({ controller: ['$dep', MyCtrl] }) で末尾識別子が class 宣言を指す場合も
     // Controller シンボルとして登録する


### PR DESCRIPTION
## 症状

\`.component('foo', { controller: SomeIdentifier, controllerAs: 'foo' })\` のように
controller プロパティが**識別子参照**で、その識別子が同一ファイル内の
\`function SomeIdentifier(...)\` (または \`class SomeIdentifier {...}\`) 宣言を
指す場合に、HTML テンプレート上の CodeLens が

\`Component: SomeIdentifier (as foo) (not found)\`

と表示されてしまっていた。\`.controller('Name', SomeIdentifier)\` 形式では
\`extract_component_definition\` が \`find_function_position\` 経由で関数宣言の
位置に Controller シンボルを登録していたが、\`.component()\` の identifier 参照
パス (\`extract_component_template_url\`) には同等の登録がなかった。

## 修正

\`extract_component_template_url\` で \`controller: Identifier\` および
\`controller: ['\$dep', Identifier]\` (DI 配列末尾識別子) の場合に、
\`register_inline_controller_definition\` ヘルパーで同一ファイル内の
\`function Identifier(...)\` / \`class Identifier {...}\` を探索して
Controller シンボルを登録するようにした。

## Test plan

- [x] \`cargo test --lib\` 全 191 件成功
- [x] 新規テスト: function 宣言参照パターン
- [x] 新規テスト: DI 配列末尾の class 宣言参照パターン
- [ ] 実プロジェクトで \`form_selector.html\` の CodeLens が \`Component: FormSelectorController (as formSelector)\` として表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)