### PR TITLE
chore: release v0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "angularjs-lsp"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bincode",
  "dashmap 6.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "angularjs-lsp"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 authors = ["mochi"]
 description = "Language Server Protocol implementation for AngularJS 1.x"

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Change Log
 
+## [0.4.1] - 2026-05-06
+
+### Fixes
+- `.component('foo', { controller: SomeIdentifier, ... })` で controller が
+  ファイル内の `function SomeIdentifier(...)` / `class SomeIdentifier {...}` を
+  identifier 参照していたとき、CodeLens が `(not found)` を表示する問題を修正
+  (PR #85)
+- 同じ class の問題が `$routeProvider.when` / `$stateProvider.state` /
+  ui-router 名前付き views / `$uibModal.open` / `$mdDialog.show` /
+  `$mdBottomSheet` / `$mdToast` / `$mdPanel.open` / `ngDialog.open` でも
+  起きていたのを `extract_template_binding_from_object` 経路で一括修正
+- `.component({ controller: Identifier, controllerAs: 'foo' })` の HTML 側
+  `foo.X` で誤った "Property is not defined" 診断と goto-definition 失敗が
+  起きていた問題を修正。`vm.X` メソッド登録時の prefix を
+  `ComponentTemplateUrl.controller_name` の決定規則と揃えた
+
 ## [0.4.0] - 2026-05-06
 
 ### Features

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "angularjs-lsp",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "angularjs-lsp",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "angularjs-lsp",
   "displayName": "AngularJS 1.x IntelliSense",
   "description": "Language Server Protocol implementation for AngularJS 1.x projects",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "icon": "icon.png",
   "publisher": "mochi33",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- v0.4.0 → v0.4.1 へバージョンを更新 (bugfix release)
- Cargo.toml / vscode-extension/package.json / package-lock.json / Cargo.lock を v0.4.1 に bump
- vscode-extension/CHANGELOG.md に v0.4.1 セクションを追記

## Fixes since v0.4.0 (PR #85)
\`.component({ controller: Identifier })\` 系の解決バグを 3 段階で修正:

1. `.component()` の identifier 参照先 \`function FooCtrl(...)\` を Controller シンボルとして登録 (CodeLens "(not found)" の解消)
2. 同型バグを \$routeProvider / \$stateProvider / ui-router views / \$uibModal / \$mdDialog 等の各経路にも展開して一括修正
3. \`vm.X\` メソッド登録 prefix を \`ComponentTemplateUrl.controller_name\` の決定規則と揃え、HTML 側 \`alias.X\` の誤 "Property is not defined" 診断 / goto-def 失敗を解消

## Release flow
マージ後に \`v0.4.1\` タグを打って push すると \`release.yml\` が走り、各プラットフォーム向けバイナリと VSIX をリリースに添付します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)