### PR TITLE
fix: .component({ controller: Identifier }) のメソッド prefix を controller…

### DIFF
--- a/src/analyzer/js/component.rs
+++ b/src/analyzer/js/component.rs
@@ -1043,11 +1043,55 @@ impl AngularJsAnalyzer {
 
                     if key_name == "controller" {
                         if let Some(value) = child.child_by_field_name("value") {
-                            self.extract_controller_methods(value, source, uri, component_name);
+                            // メソッドの prefix は controller の値から導出する。
+                            // identifier (`controller: FooCtrl`) なら `FooCtrl`、
+                            // 文字列なら文字列、名前付き関数/class ならその名前。
+                            // 匿名 inline 関数や派生不能なときだけ component_name に
+                            // フォールバックする。
+                            //
+                            // これは `ComponentTemplateUrl.controller_name` の決定ルールと
+                            // 揃える必要がある: 揃わないと alias→controller_name で引いた
+                            // controller の `.method` lookup が prefix mismatch で失敗し、
+                            // diagnostic に "Property is not defined" が出たり、
+                            // goto-definition / hover が動かなくなる。
+                            let prefix = self
+                                .derive_controller_name_for_methods(value, source)
+                                .unwrap_or_else(|| component_name.to_string());
+                            self.extract_controller_methods(value, source, uri, &prefix);
                         }
                     }
                 }
             }
+        }
+    }
+
+    /// `controller:` の値ノードから、this.X メソッド登録時に使う prefix 名を導出する。
+    /// `extract_component_template_url` が `ComponentTemplateUrl.controller_name` に
+    /// 入れる名前と同じ規則で計算する。
+    fn derive_controller_name_for_methods(&self, value: Node, source: &str) -> Option<String> {
+        match value.kind() {
+            "string" => Some(self.extract_string_value(value, source)),
+            "identifier" => Some(self.node_text(value, source).to_string()),
+            "function_expression" | "arrow_function" | "class" => value
+                .child_by_field_name("name")
+                .map(|n| self.node_text(n, source).to_string()),
+            "array" => {
+                let mut last_named: Option<Node> = None;
+                let mut cursor = value.walk();
+                for child in value.children(&mut cursor) {
+                    if child.is_named() {
+                        last_named = Some(child);
+                    }
+                }
+                last_named.and_then(|last| match last.kind() {
+                    "identifier" => Some(self.node_text(last, source).to_string()),
+                    "function_expression" | "arrow_function" | "class" => last
+                        .child_by_field_name("name")
+                        .map(|n| self.node_text(n, source).to_string()),
+                    _ => None,
+                })
+            }
+            _ => None,
         }
     }
 

--- a/src/analyzer/js/tests/mod.rs
+++ b/src/analyzer/js/tests/mod.rs
@@ -975,6 +975,90 @@ angular.module('app', [])
 }
 
 #[test]
+fn test_component_with_identifier_controller_methods_use_identifier_as_prefix() {
+    // .component('groupSelector', { controller: GroupSelectorController, controllerAs: 'groupSelector' })
+    // のとき、`vm.X` メソッドは `GroupSelectorController.X` として登録されなければならない。
+    //
+    // ComponentTemplateUrl.controller_name は識別子名 ("GroupSelectorController") を
+    // 採用するため、メソッド prefix も同じにしないと
+    // - HTML 側 `groupSelector.X` → alias 解決で "GroupSelectorController" → method lookup
+    //   が `GroupSelectorController.X` に対して走る
+    // - メソッドが component_name 派 ("groupSelector.X") で登録されていると見つからず、
+    //   "Property is not defined" 診断と goto-def 失敗が発生する
+    let index = analyze(
+        r#"
+(function() {
+    angular.module('app', [])
+    .component('groupSelector', {
+        templateUrl: 'group_selector.html',
+        controller: GroupSelectorController,
+        controllerAs: 'groupSelector',
+    });
+
+    function GroupSelectorController() {
+        var vm = this;
+        vm.showSelectGroupDialog = function() {};
+        vm.handleKeydown = function(event) {};
+    }
+}());
+"#,
+    );
+
+    // 識別子名を prefix にしたメソッドが登録されている (resolution が動く側)
+    assert!(
+        has_definition(&index, "GroupSelectorController.showSelectGroupDialog", SymbolKind::Method),
+        "vm.X methods should be registered with the controller identifier as prefix"
+    );
+    assert!(has_definition(&index, "GroupSelectorController.handleKeydown", SymbolKind::Method));
+}
+
+#[test]
+fn test_component_with_anonymous_inline_controller_methods_use_component_name_as_prefix() {
+    // 匿名 inline コントローラーは prefix を component_name にフォールバック
+    // (ComponentTemplateUrl.controller_name も effective_controller_name = component_name)
+    let index = analyze(
+        r#"
+angular.module('app', [])
+.component('myComp', {
+    templateUrl: 'my-comp.html',
+    controller: function() {
+        var vm = this;
+        vm.click = function() {};
+    },
+});
+"#,
+    );
+
+    assert!(
+        has_definition(&index, "myComp.click", SymbolKind::Method),
+        "anonymous inline controller methods should fall back to component_name as prefix"
+    );
+}
+
+#[test]
+fn test_component_with_string_controller_methods_use_string_name_as_prefix() {
+    // controller: 'StringName' のときは文字列名を prefix にする (.controller('StringName', ...) の
+    // メソッド登録と一致させて、両方からアクセス可能に)
+    let index = analyze(
+        r#"
+angular.module('app', [])
+.component('myComp', {
+    templateUrl: 'my-comp.html',
+    controller: 'MyCompCtrl',
+    controllerAs: 'vm',
+});
+
+angular.module('app').controller('MyCompCtrl', function() {
+    var vm = this;
+    vm.title = 'hi';
+});
+"#,
+    );
+
+    assert!(has_definition(&index, "MyCompCtrl.title", SymbolKind::Method));
+}
+
+#[test]
 fn test_component_with_identifier_controller_registers_function_as_controller() {
     // .component({ controller: Identifier }) で identifier が同一ファイル内の
     // function 宣言を指す場合、その関数を Controller シンボルとして登録する。


### PR DESCRIPTION
… 名と揃える

\`extract_component_controller_methods\` は今まで component_name を \`vm.X\` メソッド登録時の prefix にしていたが、
\`ComponentTemplateUrl.controller_name\` は識別子参照のとき識別子の名前を採用 していたため、HTML 側 \`alias.X\` → controller_name 解決 → \`<controller_name>.X\` ルックアップが prefix mismatch で失敗していた:

- HTML: \`groupSelector.showSelectGroupDialog\`
- alias 解決 → \"GroupSelectorController\"
- ルックアップ \`GroupSelectorController.showSelectGroupDialog\` → 不一致 (メソッドは \"groupSelector.showSelectGroupDialog\" として登録されていた)

以前は controller シンボルが \`definitions\` に未登録だったため
diagnostic / goto-def とも素通りしていて顕在化していなかったが、前 commit で identifier を Controller として登録するようになった結果、

- HTML 側 \`groupSelector.showSelectGroupDialog\` に \"Property is not defined\" 診断が誤発火
- 同じ理由で goto-definition / hover も解決失敗

を引き起こしていた。

修正: \`extract_component_controller_methods\` でも
\`ComponentTemplateUrl.controller_name\` と同じ規則 (識別子→識別子名 / 
文字列→ 文字列名 / 名前付き関数/class→その名前 / 匿名→component_name fallback) で prefix を導出するようにした。