### PR TITLE
fix: alias.property scope ref の span を property 部分のみに絞る (semantic tokens のずれ)

### DIFF
--- a/src/analyzer/html/ng_include.rs
+++ b/src/analyzer/html/ng_include.rs
@@ -622,6 +622,68 @@ mod tests {
         let _ = parent_uri;
     }
 
+    /// JS analyzer も合わせて回す版。実環境同様 `groupSelector` を controller alias
+    /// として認識させた上で HTML を解析する。
+    fn analyze_with_js(html_source: &str, js_source: &str) -> (Arc<Index>, Url, Url) {
+        let index = Arc::new(Index::new());
+        let js_analyzer = Arc::new(AngularJsAnalyzer::new(Arc::clone(&index)));
+        let html = HtmlAngularJsAnalyzer::new(Arc::clone(&index), Arc::clone(&js_analyzer));
+        let html_uri = Url::parse("file:///test.html").unwrap();
+        let js_uri = Url::parse("file:///test.js").unwrap();
+
+        // JS 先行解析 (alias 解決のため)
+        js_analyzer.analyze_document(&js_uri, js_source);
+        html.analyze_document(&html_uri, html_source);
+        (index, html_uri, js_uri)
+    }
+
+    #[test]
+    fn alias_dot_property_ref_covers_only_property_span() {
+        // 以前は `alias.property` 形式の参照が **alias + dot + property 全体** を
+        // 覆う position で登録されていた。dedup の overlap ルール (長い token 優先) で
+        // alias 単独 ref が消され、結果として alias 部分まで METHOD 色で塗られていた
+        // (ユーザーから見ると「token がずれている」状態)。
+        //
+        // 修正後は `alias.property` ref の span は **property 部分のみ** を覆い、
+        // `alias` 単独 ref と被らないので両方が semantic token として正しく描画される。
+        let html = "<div ng-click=\"groupSelector.showSelectGroupDialog()\"></div>\n";
+        let js = "angular.module('app', []).component('groupSelector', {\n  templateUrl: 'test.html',\n  controller: function() { var vm = this; vm.showSelectGroupDialog = function() {}; },\n  controllerAs: 'groupSelector',\n});\n";
+        let (index, uri, _) = analyze_with_js(html, js);
+
+        let refs = index.html.get_html_scope_references(&uri);
+        let lines: Vec<&str> = html.lines().collect();
+
+        let alias_ref = refs
+            .iter()
+            .find(|r| r.property_path == "groupSelector")
+            .expect("alias 単独 ref が存在するはず");
+        let combined_ref = refs
+            .iter()
+            .find(|r| r.property_path == "groupSelector.showSelectGroupDialog")
+            .expect("alias.property ref が存在するはず");
+
+        let span_text = |r: &crate::model::HtmlScopeReference| -> String {
+            let line = lines[r.start_line as usize];
+            let line_utf16: Vec<u16> = line.encode_utf16().collect();
+            String::from_utf16_lossy(&line_utf16[r.start_col as usize..r.end_col as usize])
+        };
+
+        assert_eq!(span_text(alias_ref), "groupSelector");
+        // alias.property ref の span は **property のみ** を指していること
+        assert_eq!(
+            span_text(combined_ref),
+            "showSelectGroupDialog",
+            "alias.property ref の span は property のみを覆うべき"
+        );
+
+        // 2つの ref は overlap しないこと (encode_tokens dedup で消されない)
+        assert!(
+            alias_ref.end_col <= combined_ref.start_col
+                || combined_ref.end_col <= alias_ref.start_col,
+            "alias と alias.property の span は overlap してはいけない"
+        );
+    }
+
     #[test]
     fn ng_controller_reference_position_is_utf16_when_line_has_japanese() {
         // ng-controller のシンボル参照位置も UTF-16 化していないと、

--- a/src/analyzer/html/scope_reference.rs
+++ b/src/analyzer/html/scope_reference.rs
@@ -144,9 +144,16 @@ impl HtmlAngularJsAnalyzer {
             let positions = self.find_identifier_positions(value, property_path);
 
             for (byte_offset, byte_len) in positions {
-                let identifier_text = &value[byte_offset..byte_offset + byte_len];
+                // alias.property 形式の場合、span は property 部分のみを覆うようにする。
+                // (`alias` は別の単独 ref として登録されるため、両者を別位置にすることで
+                //  semantic tokens の overlap dedup で alias 部分が消えなくなる)
+                let (span_byte_offset, span_byte_len) = match property_path.find('.') {
+                    Some(dot_idx) => (byte_offset + dot_idx + 1, byte_len - dot_idx - 1),
+                    None => (byte_offset, byte_len),
+                };
+                let identifier_text = &value[span_byte_offset..span_byte_offset + span_byte_len];
                 let (start_line, start_col) =
-                    self.position_in_text(value, byte_offset, value_start_line, value_start_col);
+                    self.position_in_text(value, span_byte_offset, value_start_line, value_start_col);
                 let end_line = start_line; // 識別子は1行内と仮定
                 let end_col = start_col + identifier_text.chars().map(|c| c.len_utf16()).sum::<usize>() as u32;
 
@@ -226,9 +233,15 @@ impl HtmlAngularJsAnalyzer {
                     let positions = self.find_identifier_positions(expr_trimmed, property_path);
 
                     for (byte_offset, byte_len) in positions {
-                        let identifier_text = &expr_trimmed[byte_offset..byte_offset + byte_len];
+                        // alias.property は property 部分のみを span にする
+                        let (span_byte_offset, span_byte_len) = match property_path.find('.') {
+                            Some(dot_idx) => (byte_offset + dot_idx + 1, byte_len - dot_idx - 1),
+                            None => (byte_offset, byte_len),
+                        };
+                        let identifier_text =
+                            &expr_trimmed[span_byte_offset..span_byte_offset + span_byte_len];
                         let (start_line, start_col) =
-                            self.position_in_text(expr_trimmed, byte_offset, expr_line, expr_col);
+                            self.position_in_text(expr_trimmed, span_byte_offset, expr_line, expr_col);
                         let end_line = start_line;
                         let end_col = start_col + identifier_text.chars().map(|c| c.len_utf16()).sum::<usize>() as u32;
 
@@ -428,9 +441,15 @@ impl HtmlAngularJsAnalyzer {
                     let positions = self.find_identifier_positions(expr_trimmed, &property_path);
 
                     for (byte_offset, byte_len) in positions {
-                        let identifier_text = &expr_trimmed[byte_offset..byte_offset + byte_len];
+                        // alias.property は property 部分のみを span にする
+                        let (span_byte_offset, span_byte_len) = match property_path.find('.') {
+                            Some(dot_idx) => (byte_offset + dot_idx + 1, byte_len - dot_idx - 1),
+                            None => (byte_offset, byte_len),
+                        };
+                        let identifier_text =
+                            &expr_trimmed[span_byte_offset..span_byte_offset + span_byte_len];
                         let (start_line, start_col) =
-                            self.position_in_text(expr_trimmed, byte_offset, expr_line, expr_col);
+                            self.position_in_text(expr_trimmed, span_byte_offset, expr_line, expr_col);
                         let end_line = start_line;
                         let end_col = start_col + identifier_text.chars().map(|c| c.len_utf16()).sum::<usize>() as u32;
 


### PR DESCRIPTION
## 症状

\`<div ng-click=\"groupSelector.showSelectGroupDialog()\">\` のような式について、
**ファイル編集後**に \`groupSelector.showSelectGroupDialog\` 全体 (alias + dot + method の 35文字)
が METHOD 色で塗られてしまい、ユーザーから見ると **alias 部分が想定と違う色になっている = ずれている** 状態。

## 原因

\`parse_angular_expression\` は \`groupSelector.showSelectGroupDialog\` と \`groupSelector\` の両方を identifier として返す。これらをそのまま \`find_identifier_positions\` に渡すと:

| property_path | span (utf-16 col) | 内容 |
|---|---|---|
| \`groupSelector.showSelectGroupDialog\` | 15..50 (35文字) | alias + dot + method 全体 |
| \`groupSelector\` | 15..28 (13文字) | alias のみ |

両者が同じ \`start_col=15\` で始まり、\`encode_tokens\` の overlap dedup ルール (長い token 優先) で alias 単独 ref が消える。結果、alias と dot まで METHOD 色になる。

「**編集後**にずれる」と特定された動作は次のように説明できる:

1. 初回解析 (もしくは alias 未登録時点): \`resolve_controller_by_alias\` が \`groupSelector\` を解決できないため、\`alias.property\` 形式の ref はフィルタで弾かれる ([\`scope_reference.rs:128\`](src/analyzer/html/scope_reference.rs))。短い \`alias\` ref だけが残ってトークンは正しい位置で描画される。
2. JS が解析されて alias が解決可能になった後の再解析: \`alias.property\` ref が追加され、長い span が dedup を勝ち上がる → ハイライト範囲が拡張されて見える = ずれて見える。

## 修正

\`register_scope_references\` と \`extract_interpolation_references_from_*\` の3箇所で、\`property_path\` に \`.\` を含む参照を登録するとき、byte_offset を \`dot+1\` だけ進めて **property 部分のみ** を span にするようにした (\`scope_reference.rs\`)。

修正後:

| property_path | span | 内容 |
|---|---|---|
| \`groupSelector.showSelectGroupDialog\` | 29..50 | \`showSelectGroupDialog\` のみ |
| \`groupSelector\` | 15..28 | \`groupSelector\` のみ |

overlap せず両方が個別の semantic token として残る。

副次効果: \`find_html_scope_reference_at(uri, line, col_on_alias)\` が今度は alias 単独 ref を返すようになるため、cursor on alias での goto-definition / hover が controller を正しく扱えるようになる (これまでは長い ref が拾われて property を resolve しようとしていた)。

## Test plan

- [x] \`cargo test --lib\` 全 202 件 pass
- [x] 新規テスト \`alias_dot_property_ref_covers_only_property_span\`: alias と alias.property の span が overlap せず、それぞれの span text が \`groupSelector\` / \`showSelectGroupDialog\` であることを assert
- [ ] 実プロジェクトで \`groupSelector.showSelectGroupDialog\` の semantic token が \`groupSelector\` (VARIABLE) と \`showSelectGroupDialog\` (METHOD) に分かれて正しく描画されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)