### PR TITLE
fix: 同一ファイル編集後も semantic_tokens_refresh を発火 (token 位置ずれ)

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -737,13 +737,18 @@ impl Backend {
                         publish_js_diagnostics(&client, &index, &diagnostics_config, &js_uri).await;
                     }
 
-                    // semantic_tokens_refresh / code_lens_refresh はどちらも workspace
-                    // 全 applicable ファイルに再要求が走る重い操作。cross-file dep の
-                    // 状態変化が無ければスキップする。HTML 自身のスコープ参照変化
-                    // (`{{vm.foo}}` 追加など) は当該 HTML のトークン/lens にしか影響
-                    // せず、それは LSP クライアントが didChange 後に自動再要求する。
+                    // semantic_tokens_refresh は同一ファイル編集でも必ず発火する。
+                    // クライアントは didChange 後に semantic_tokens を自動再要求するが、
+                    // それは「即時」に起きるため、debounce (200ms) 後の再解析が完了する
+                    // 前に走り、stale な position を取得してしまう。サーバー側で再解析
+                    // 完了後に refresh 信号を送らないと、VS Code は古い position を
+                    // 新しいバッファに適用し続けてハイライトがずれる
+                    // (「編集後セマンティックトークンがずれる」症状の原因)。
+                    //
+                    // code_lens_refresh は cross-file 依存が変化したときだけでよい
+                    // (lens は CodeLens のリンク先に依存するため)
+                    let _ = client.semantic_tokens_refresh().await;
                     if before.cross_file_lens_state_changed(&after) {
-                        let _ = client.semantic_tokens_refresh().await;
                         let _ = client.code_lens_refresh().await;
                     }
                 }


### PR DESCRIPTION
## 症状

HTML ファイルを編集すると、編集後にセマンティックトークンが実際のシンボル位置からずれる。**文字コード (UTF-16) と無関係な ASCII のみの行でも発生**。

## 原因

\`on_change\` (HTML パス) は debounce 200ms 後に再解析を行い、解析後に \`semantic_tokens_refresh\` を発火する。ただし発火条件が

\`\`\`rust
if before.cross_file_lens_state_changed(&after) {
    let _ = client.semantic_tokens_refresh().await;
    let _ = client.code_lens_refresh().await;
}
\`\`\`

でガードされており、**同一ファイル内の変更 (cross-file dep が変化しない場合)** は refresh が発火しない設計だった。コメントには「VS Code は didChange 後に自動再要求するから不要」と書かれているが、実際の挙動は次の通り:

1. ユーザーがキー入力 → didChange を即送信
2. VS Code は **didChange を受け取った直後** に semantic_tokens を再要求
3. サーバーは **再解析がまだ走る前** の index (= 旧 position) を返す
4. VS Code は **古い position** を **新しい text** にそのまま適用 → ハイライトが文字数ぶんずれる
5. 200ms 後に再解析が完了 → でも cross-file 変化がないと \`semantic_tokens_refresh\` が呼ばれない → VS Code はもう再要求しないので **古い (ずれた) ハイライトのまま固定**

## 修正

cross-file gate を **\`code_lens_refresh\`** にだけ残し、\`semantic_tokens_refresh\` は再解析完了後に必ず発火するようにした。これで debounce 後の最新 index に基づいてクライアントが再要求するため、編集後のずれが解消する。

## Test plan

- [x] \`cargo test --lib\` 全 202 件 pass
- [ ] 実プロジェクトで HTML を編集後、セマンティックトークンの位置が文字入力ごとに正しく追従することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)