### PR TITLE
chore: release v0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "angularjs-lsp"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "bincode",
  "dashmap 6.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "angularjs-lsp"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 authors = ["mochi"]
 description = "Language Server Protocol implementation for AngularJS 1.x"

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Change Log
 
+## [0.4.2] - 2026-05-07
+
+### Fixes
+- HTML 編集後にセマンティックトークン位置が実際のシンボル位置からずれる問題を修正 (PR #91)
+  - cross-file dep 変化がない同一ファイル編集でも `semantic_tokens_refresh` を
+    必ず発火するようにした。これがないと VS Code が didChange 直後に取得した
+    旧 position をそのまま新しいバッファに適用し続けてハイライトがずれていた
+- `alias.property` 形式の `HtmlScopeReference` の span を property 部分のみに
+  絞って登録するように変更 (PR #90)。以前は alias + dot + property 全体を
+  覆う長い span が登録されていて、overlap dedup により alias 単独 token が
+  消され METHOD 色が alias 部分まで広がっていた
+- HTML 解析の position を UTF-16 単位に統一 (PR #88)。`<form name="X">` の
+  HtmlFormBinding、ng-controller の SymbolReference、ng-repeat / ng-init の
+  継承ローカル変数で tree-sitter の byte column を直接保存していた箇所を
+  `byte_col_to_utf16_col` 経由に修正
+
 ## [0.4.1] - 2026-05-06
 
 ### Fixes

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "angularjs-lsp",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "angularjs-lsp",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "angularjs-lsp",
   "displayName": "AngularJS 1.x IntelliSense",
   "description": "Language Server Protocol implementation for AngularJS 1.x projects",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "icon": "icon.png",
   "publisher": "mochi33",
   "license": "MIT",


### PR DESCRIPTION
## Summary
v0.4.1 → v0.4.2 (bugfix release)

## Fixes since v0.4.1
- **PR #91**: HTML 編集後にセマンティックトークン位置がずれる問題 (同一ファイル編集後も \`semantic_tokens_refresh\` を必ず発火)
- **PR #90**: \`alias.property\` 形式の HtmlScopeReference の span を property 部分のみに絞り、alias 単独 token と overlap しないように
- **PR #88**: HTML 解析の column を UTF-16 単位に統一 (form binding / ng-controller / ng-repeat 継承)

## Release flow
マージ後に \`v0.4.2\` タグを打って push すると \`release.yml\` が走り、各プラットフォーム向けバイナリと VSIX をリリースに添付します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)